### PR TITLE
Separate node error from error

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -29,7 +29,7 @@ class LimitdRedis extends EventEmitter {
   constructor(params) {
     super();
 
-    this.db = new LimitDBRedis(_.pick(params, ['uri', 'nodes', 'buckets', 'prefix', 'slotsRefreshTimeout', 'password', 'tls', 'dnsLookup', 'globalTTL']));
+    this.db = new LimitDBRedis(_.pick(params, ['uri', 'nodes', 'buckets', 'prefix', 'slotsRefreshTimeout', 'slotsRefreshInterval', 'password', 'tls', 'dnsLookup', 'globalTTL']));
 
     this.db.on('error', (err) => {
       this.emit('error', err);
@@ -37,6 +37,10 @@ class LimitdRedis extends EventEmitter {
 
     this.db.on('ready', () => {
       this.emit('ready');
+    });
+
+    this.db.on('node error', (err, node) => {
+      this.emit('node error', err, node);
     });
 
     this.breakerOpts = _.merge(circuitBreakerDefaults, params.circuitbreaker);

--- a/lib/db.js
+++ b/lib/db.js
@@ -40,7 +40,8 @@ class LimitDBRedis extends EventEmitter {
     };
 
     const clusterOptions = {
-      slotsRefreshTimeout: config.slotsRefreshTimeout || 2000,
+      slotsRefreshTimeout: config.slotsRefreshTimeout || 3000,
+      slotsRefreshInterval: config.slotsRefreshInterval || ms('5m'),
       keyPrefix: config.prefix,
       dnsLookup: config.dnsLookup,
       enableReadyCheck: true,
@@ -72,8 +73,8 @@ class LimitDBRedis extends EventEmitter {
       this.emit('error', err);
     });
 
-    this.redis.on('node error', (err) => {
-      this.emit('error', err);
+    this.redis.on('node error', (err, node) => {
+      this.emit('node error', err, node);
     });
   }
 


### PR DESCRIPTION
Increase the frequency in which slots are calculated to 5 minutes. In the case of a failover, the first `MOVED` will force a slots refresh faster thus reducing the impact window significantly.

Increase the slots command timeout to 3s (failure can be tolerated most of the time).

Separate the node errors from the actual errors. Therefore full cluster errors will go through `error` while a single node timing out would go into `node errors`