### PR TITLE
[CAUTH-954] Pass in bucket configuration at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ typings/
 
 # Profiler
 *.0x
+
+# test garbage
+dump.rdb

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ limitd.take(type, key, [count], (err, result) => {
 -  `type`: the bucket type.
 -  `key`: the identifier of the bucket.
 -  `count`: the amount of tokens you need. This is optional and the default is 1.
+-  `configOverride`: caller-provided bucket configuration for this operation
 
 The result object has:
 
@@ -135,6 +136,29 @@ limitd.put(type, key, [count], (err, result) => {
 -  `type`: the bucket type.
 -  `key`: the identifier of the bucket.
 -  `count`: the amount of tokens you want to put in the bucket. This is optional and the default is the size of the bucket.
+-  `configOverride`: caller-provided bucket configuration for this operation
+
+## Overriding Configuration at Runtime
+Since the method of storing overrides for buckets in memory does not scale to a large number, limitd-redis provides a way for callers to pass in configuration from an external data store.  The shape of this `configOverride` parameter (available on `take`, `put`, `get`, and `wait`) is exactly the same as `Buckets` above ^.
+
+An example configuration override call might look like this:
+
+```js
+const configOverride = {
+  size: 45,
+  per_hour: 15
+}
+// take one
+limitd.take(type, key, { configOverride }, (err, result) => {
+  console.log(result);
+}
+// take multiple
+limitd.take(type, key, { count: 3, configOverride }, (err, result) => {
+  console.log(result);
+}););
+```
+
+Config overrides follow the same rules as Bucket configuration elements with respect to default size when not provided and ttl.
 
 ## Author
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,12 +1,12 @@
 const _ = require('lodash');
 const retry = require('retry');
 const cbControl = require('cb');
-const utils = require('./utils');
+const validation = require('./validation');
 const LimitDBRedis = require('./db');
 const disyuntor = require('disyuntor');
 const EventEmitter = require('events').EventEmitter;
 
-const ValidationError = utils.LimitdRedisValidationError;
+const ValidationError = validation.LimitdRedisValidationError;
 
 const circuitBreakerDefaults = {
   timeout: '0.25s',

--- a/lib/db.js
+++ b/lib/db.js
@@ -100,7 +100,7 @@ class LimitDBRedis extends EventEmitter {
    */
   bucketKeyConfig(type, params) {
     if (typeof params.configOverride === 'object') {
-      return utils.normalizeType(params.configOverride);
+      return utils.normalizeTemporals(params.configOverride);
     }
 
     const fromCache = type.overridesCache.get(params.key);

--- a/lib/db.js
+++ b/lib/db.js
@@ -5,7 +5,6 @@ const async = require('async');
 const utils = require('./utils');
 const Redis = require('ioredis');
 const EventEmitter = require('events').EventEmitter;
-const { type } = require('os');
 const { validateParams } = require('./validation');
 
 const TAKE_LUA = fs.readFileSync(`${__dirname}/take.lua`, 'utf8');

--- a/lib/db.js
+++ b/lib/db.js
@@ -348,7 +348,7 @@ module.exports = LimitDBRedis;
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
  * @property {integer} [count=1] The number of tokens to take from the bucket.
- * @property {type} config Externally provided bucket configruation
+ * @property {type} configOverride Externally provided bucket configruation
  *
  * @typedef takeResult
  * @property {boolean} conformant Returns true if there is enough capacity in the bucket and the tokens has been removed.
@@ -360,7 +360,7 @@ module.exports = LimitDBRedis;
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
  * @property {integer} [count=1] The number of tokens to wait for.
- * @property {type} config Externally provided bucket configruation
+ * @property {type} configOverride Externally provided bucket configruation
  *
  * @typedef waitResult
  * @property {integer} remaining The number of tokens remaining in the bucket.
@@ -371,7 +371,7 @@ module.exports = LimitDBRedis;
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
  * @property {integer} [count=SIZE] The number of tokens to put in the bucket. Defaults to the size of the bucket.
- * @property {type} config Externally provided bucket configruation
+ * @property {type} configOverride Externally provided bucket configruation
  *
  * @typedef putResult
  * @property {integer} remaining The number of tokens remaining in the bucket.
@@ -381,7 +381,7 @@ module.exports = LimitDBRedis;
  * @typedef getParams
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
- * @property {type} config Externally provided bucket configruation
+ * @property {type} configOverride Externally provided bucket configruation
  *
  * @typedef getResult
  * @property {integer} remaining The number of tokens remaining in the bucket.

--- a/lib/db.js
+++ b/lib/db.js
@@ -96,10 +96,10 @@ class LimitDBRedis extends EventEmitter {
     const bucketConfig = {};
 
     if (params && params.configOverride) {
-      if (params.configOverride.bucketSize) {
+      if (typeof params.configOverride.bucketSize === 'number') {
         bucketConfig.size = params.configOverride.bucketSize;
       }
-      if (params.configOverride.refillRateMsPerToken) {
+      if (typeof params.configOverride.refillRateMsPerToken === 'number') {
         bucketConfig.per_interval = 1;
         bucketConfig.interval = params.configOverride.refillRateMsPerToken;
       }
@@ -117,7 +117,7 @@ class LimitDBRedis extends EventEmitter {
     const fromCache = type.overridesCache.get(params.key);
 
     if (fromCache) {
-      return _.merge(fromCache, this.paramsToBucketConfig(params));
+      return { ...fromCache, ...this.paramsToBucketConfig(params)};
     }
 
     const result = _.find(type.overrides, (o) => {
@@ -130,7 +130,7 @@ class LimitDBRedis extends EventEmitter {
 
     type.overridesCache.set(params.key, result);
 
-    return _.merge(result, this.paramsToBucketConfig(params));
+    return { ...result, ...this.paramsToBucketConfig(params)};
   }
 
   calculateReset(bucketKeyConfig, remaining, now) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -92,9 +92,6 @@ class LimitDBRedis extends EventEmitter {
     this.buckets[key] = utils.buildBucket(bucket);
   }
 
-  /**
-   * @param {bucketConfigParams} params
-   */
   paramsToBucketConfig(params) {
     const bucketConfig = {};
 
@@ -102,7 +99,10 @@ class LimitDBRedis extends EventEmitter {
       if (params.configOverride.bucketSize) {
         bucketConfig.size = params.configOverride.bucketSize;
       }
-      // TODO rate/interval
+      if (params.configOverride.refillRateMsPerToken) {
+        bucketConfig.per_interval = 1;
+        bucketConfig.interval = params.configOverride.refillRateMsPerToken;
+      }
     }
 
     return bucketConfig;
@@ -110,7 +110,7 @@ class LimitDBRedis extends EventEmitter {
 
   /**
    * @param {string} type
-   * @param {bucketConfigParams} params
+   * @param {object} params
    * @returns
    */
   bucketKeyConfig(type, params) {
@@ -144,6 +144,10 @@ class LimitDBRedis extends EventEmitter {
     return Math.ceil((now + msToCompletion) / 1000);
   }
 
+  /**
+   * @param {bucketConfigParams} params
+   * @returns {void} nothing if valid, ValidationError if invalid
+   */
   validateParams(params) {
     if (typeof params !== 'object') {
       return new ValidationError('params are required', { code: 101 });
@@ -192,10 +196,8 @@ class LimitDBRedis extends EventEmitter {
       });
     }
 
-    console.log(`calculated tokens_per_ms from per_interval of ${bucketKeyConfig.per_interval} and interval ${bucketKeyConfig.interval} = ${bucketKeyConfig.per_interval / bucketKeyConfig.interval}`);
-    const bleh = bucketKeyConfig.per_interval / bucketKeyConfig.interval || 0;
     this.redis.take(`${params.type}:${params.key}`,
-      bleh,
+      bucketKeyConfig.per_interval / bucketKeyConfig.interval || 0,
       bucketKeyConfig.size,
       count,
       Math.floor(bucketKeyConfig.ttl || this.globalTTL),
@@ -328,9 +330,10 @@ class LimitDBRedis extends EventEmitter {
           return callback(err);
         }
 
-        const remaining = parseInt(results[0], 10);
+        let remaining = parseInt(results[0], 10);
+        remaining = Number.isInteger(remaining) ? remaining : bucketKeyConfig.size;
         return callback(null, {
-          remaining: Number.isInteger(remaining) ? remaining : bucketKeyConfig.size,
+          remaining,
           reset: this.calculateReset(bucketKeyConfig, remaining, parseInt(results[1], 10)),
           limit: bucketKeyConfig.size
         });
@@ -374,14 +377,14 @@ module.exports = LimitDBRedis;
  * @property {string} [params.prefix] Prefix keys in Redis.
  *
  * @typedef {Object} configOverride
- * @property {integer} bucketSize
- * @property {integer} tokensPerMs
+ * @property {integer} bucketSize capacity of the bucket
+ * @property {integer} refillRateMsPerToken rate of bucket refill, given as number of milliseconds per token
  *
  * @typedef takeParams
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
- * @property {configOverride} config Externally provided bucket configruation
  * @property {integer} [count=1] The number of tokens to take from the bucket.
+ * @property {configOverride} config Externally provided bucket configruation
  *
  * @typedef takeResult
  * @property {boolean} conformant Returns true if there is enough capacity in the bucket and the tokens has been removed.
@@ -392,8 +395,8 @@ module.exports = LimitDBRedis;
  * @typedef waitParams
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
- * @property {configOverride} config Externally provided bucket configruation
  * @property {integer} [count=1] The number of tokens to wait for.
+ * @property {configOverride} config Externally provided bucket configruation
  *
  * @typedef waitResult
  * @property {integer} remaining The number of tokens remaining in the bucket.
@@ -403,8 +406,8 @@ module.exports = LimitDBRedis;
  * @typedef putParams
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
- * @property {configOverride} config Externally provided bucket configruation
  * @property {integer} [count=SIZE] The number of tokens to put in the bucket. Defaults to the size of the bucket.
+ * @property {configOverride} config Externally provided bucket configruation
  *
  * @typedef putResult
  * @property {integer} remaining The number of tokens remaining in the bucket.
@@ -420,5 +423,4 @@ module.exports = LimitDBRedis;
  * @property {integer} remaining The number of tokens remaining in the bucket.
  * @property {integer} reset A unix timestamp indicating when the bucket is going to be full.
  * @property {integer} limit The size of the bucket.
- *
 */

--- a/lib/db.js
+++ b/lib/db.js
@@ -5,8 +5,9 @@ const async = require('async');
 const utils = require('./utils');
 const Redis = require('ioredis');
 const EventEmitter = require('events').EventEmitter;
+const { type } = require('os');
+const { validateParams } = require('./validation');
 
-const ValidationError = utils.LimitdRedisValidationError;
 const TAKE_LUA = fs.readFileSync(`${__dirname}/take.lua`, 'utf8');
 const PUT_LUA = fs.readFileSync(`${__dirname}/put.lua`, 'utf8');
 
@@ -92,32 +93,19 @@ class LimitDBRedis extends EventEmitter {
     this.buckets[key] = utils.buildBucket(bucket);
   }
 
-  paramsToBucketConfig(params) {
-    const bucketConfig = {};
-
-    if (params && params.configOverride) {
-      if (typeof params.configOverride.bucketSize === 'number') {
-        bucketConfig.size = params.configOverride.bucketSize;
-      }
-      if (typeof params.configOverride.refillRateMsPerToken === 'number') {
-        bucketConfig.per_interval = 1;
-        bucketConfig.interval = params.configOverride.refillRateMsPerToken;
-      }
-    }
-
-    return bucketConfig;
-  }
-
   /**
    * @param {string} type
    * @param {object} params
    * @returns
    */
   bucketKeyConfig(type, params) {
-    const fromCache = type.overridesCache.get(params.key);
+    if (typeof params.configOverride === 'object') {
+      return utils.normalizeType(params.configOverride);
+    }
 
+    const fromCache = type.overridesCache.get(params.key);
     if (fromCache) {
-      return { ...fromCache, ...this.paramsToBucketConfig(params)};
+      return fromCache;
     }
 
     const result = _.find(type.overrides, (o) => {
@@ -130,7 +118,7 @@ class LimitDBRedis extends EventEmitter {
 
     type.overridesCache.set(params.key, result);
 
-    return { ...result, ...this.paramsToBucketConfig(params)};
+    return result;
   }
 
   calculateReset(bucketKeyConfig, remaining, now) {
@@ -144,27 +132,6 @@ class LimitDBRedis extends EventEmitter {
     return Math.ceil((now + msToCompletion) / 1000);
   }
 
-  /**
-   * @param {bucketConfigParams} params
-   * @returns {void} nothing if valid, ValidationError if invalid
-   */
-  validateParams(params) {
-    if (typeof params !== 'object') {
-      return new ValidationError('params are required', { code: 101 });
-    }
-
-    if (typeof params.type !== 'string') {
-      return new ValidationError('type is required', { code: 102 });
-    }
-
-    if (typeof this.buckets[params.type] === 'undefined') {
-      return new ValidationError(`undefined bucket type ${params.type}`, { code: 103 });
-    }
-
-    if (typeof params.key !== 'string') {
-      return new ValidationError('key is required', { code: 104 });
-    }
-  }
 
   /**
    * Take N elements from a bucket if available.
@@ -173,7 +140,7 @@ class LimitDBRedis extends EventEmitter {
    * @param {function(Error, takeResult)} callback.
    */
   take(params, callback) {
-    const valError = this.validateParams(params);
+    const valError = validateParams(params, this.buckets);
     if (valError) {
       return process.nextTick(callback, valError);
     }
@@ -257,7 +224,7 @@ class LimitDBRedis extends EventEmitter {
   put(params, callback) {
     callback = callback || _.noop;
 
-    const valError = this.validateParams(params);
+    const valError = validateParams(params, this.buckets);
     if (valError) {
       return process.nextTick(callback, valError);
     }
@@ -307,7 +274,7 @@ class LimitDBRedis extends EventEmitter {
   get(params, callback) {
     callback = callback || _.noop;
 
-    const valError = this.validateParams(params);
+    const valError = validateParams(params, this.buckets);
     if (valError) {
       return process.nextTick(callback, valError);
     }
@@ -375,16 +342,13 @@ module.exports = LimitDBRedis;
  * @property {Object.<string, object>} [params.nodes] Redis Cluster Configuration https://github.com/luin/ioredis#cluster".
  * @property {Object.<string, type>} [params.types] The buckets configuration.
  * @property {string} [params.prefix] Prefix keys in Redis.
- *
- * @typedef {Object} configOverride
- * @property {integer} bucketSize capacity of the bucket
- * @property {integer} refillRateMsPerToken rate of bucket refill, given as number of milliseconds per token
+ * @property {type} [params.configOverride] Bucket configuration override
  *
  * @typedef takeParams
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
  * @property {integer} [count=1] The number of tokens to take from the bucket.
- * @property {configOverride} config Externally provided bucket configruation
+ * @property {type} config Externally provided bucket configruation
  *
  * @typedef takeResult
  * @property {boolean} conformant Returns true if there is enough capacity in the bucket and the tokens has been removed.
@@ -396,7 +360,7 @@ module.exports = LimitDBRedis;
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
  * @property {integer} [count=1] The number of tokens to wait for.
- * @property {configOverride} config Externally provided bucket configruation
+ * @property {type} config Externally provided bucket configruation
  *
  * @typedef waitResult
  * @property {integer} remaining The number of tokens remaining in the bucket.
@@ -407,7 +371,7 @@ module.exports = LimitDBRedis;
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
  * @property {integer} [count=SIZE] The number of tokens to put in the bucket. Defaults to the size of the bucket.
- * @property {configOverride} config Externally provided bucket configruation
+ * @property {type} config Externally provided bucket configruation
  *
  * @typedef putResult
  * @property {integer} remaining The number of tokens remaining in the bucket.
@@ -417,7 +381,7 @@ module.exports = LimitDBRedis;
  * @typedef getParams
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
- * @property {configOverride} config Externally provided bucket configruation
+ * @property {type} config Externally provided bucket configruation
  *
  * @typedef getResult
  * @property {integer} remaining The number of tokens remaining in the bucket.

--- a/lib/db.js
+++ b/lib/db.js
@@ -92,24 +92,45 @@ class LimitDBRedis extends EventEmitter {
     this.buckets[key] = utils.buildBucket(bucket);
   }
 
-  bucketKeyConfig(type, key) {
-    const fromCache = type.overridesCache.get(key);
+  /**
+   * @param {bucketConfigParams} params
+   */
+  paramsToBucketConfig(params) {
+    const bucketConfig = {};
+
+    if (params && params.configOverride) {
+      if (params.configOverride.bucketSize) {
+        bucketConfig.size = params.configOverride.bucketSize;
+      }
+      // TODO rate/interval
+    }
+
+    return bucketConfig;
+  }
+
+  /**
+   * @param {string} type
+   * @param {bucketConfigParams} params
+   * @returns
+   */
+  bucketKeyConfig(type, params) {
+    const fromCache = type.overridesCache.get(params.key);
 
     if (fromCache) {
-      return fromCache;
+      return _.merge(fromCache, this.paramsToBucketConfig(params));
     }
 
     const result = _.find(type.overrides, (o) => {
       if (o.match) {
-        return o.match.exec(key);
+        return o.match.exec(params.key);
       } else {
-        return o.name === key;
+        return o.name === params.key;
       }
     }) || type;
 
-    type.overridesCache.set(key, result);
+    type.overridesCache.set(params.key, result);
 
-    return result;
+    return _.merge(result, this.paramsToBucketConfig(params));
   }
 
   calculateReset(bucketKeyConfig, remaining, now) {
@@ -137,7 +158,7 @@ class LimitDBRedis extends EventEmitter {
     }
 
     if (typeof params.key !== 'string') {
-      return new ValidationError('key is required', { code: 104});
+      return new ValidationError('key is required', { code: 104 });
     }
   }
 
@@ -154,7 +175,7 @@ class LimitDBRedis extends EventEmitter {
     }
 
     const bucket = this.buckets[params.type];
-    const bucketKeyConfig = this.bucketKeyConfig(bucket, params.key);
+    const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
     let count = params.count || 1;
     if (count === 'all') {
@@ -171,8 +192,10 @@ class LimitDBRedis extends EventEmitter {
       });
     }
 
+    console.log(`calculated tokens_per_ms from per_interval of ${bucketKeyConfig.per_interval} and interval ${bucketKeyConfig.interval} = ${bucketKeyConfig.per_interval / bucketKeyConfig.interval}`);
+    const bleh = bucketKeyConfig.per_interval / bucketKeyConfig.interval || 0;
     this.redis.take(`${params.type}:${params.key}`,
-      bucketKeyConfig.per_interval / bucketKeyConfig.interval || 0,
+      bleh,
       bucketKeyConfig.size,
       count,
       Math.floor(bucketKeyConfig.ttl || this.globalTTL),
@@ -206,7 +229,7 @@ class LimitDBRedis extends EventEmitter {
       }
 
       const bucket = this.buckets[params.type];
-      const bucketKeyConfig = this.bucketKeyConfig(bucket, params.key);
+      const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
       const count = params.count || 1;
       const required = count - result.remaining;
       const minWait = Math.ceil(required * bucketKeyConfig.interval / bucketKeyConfig.per_interval);
@@ -238,7 +261,7 @@ class LimitDBRedis extends EventEmitter {
     }
 
     const bucket = this.buckets[params.type];
-    const bucketKeyConfig = this.bucketKeyConfig(bucket, params.key);
+    const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
     let count = params.count || 'all';
     if (count === 'all') {
@@ -288,7 +311,7 @@ class LimitDBRedis extends EventEmitter {
     }
 
     const bucket = this.buckets[params.type];
-    const bucketKeyConfig = this.bucketKeyConfig(bucket, params.key);
+    const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
     if (bucketKeyConfig.unlimited) {
       return process.nextTick(callback, null, {
@@ -350,9 +373,14 @@ module.exports = LimitDBRedis;
  * @property {Object.<string, type>} [params.types] The buckets configuration.
  * @property {string} [params.prefix] Prefix keys in Redis.
  *
+ * @typedef {Object} configOverride
+ * @property {integer} bucketSize
+ * @property {integer} tokensPerMs
+ *
  * @typedef takeParams
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
+ * @property {configOverride} config Externally provided bucket configruation
  * @property {integer} [count=1] The number of tokens to take from the bucket.
  *
  * @typedef takeResult
@@ -364,6 +392,7 @@ module.exports = LimitDBRedis;
  * @typedef waitParams
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
+ * @property {configOverride} config Externally provided bucket configruation
  * @property {integer} [count=1] The number of tokens to wait for.
  *
  * @typedef waitResult
@@ -374,6 +403,7 @@ module.exports = LimitDBRedis;
  * @typedef putParams
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
+ * @property {configOverride} config Externally provided bucket configruation
  * @property {integer} [count=SIZE] The number of tokens to put in the bucket. Defaults to the size of the bucket.
  *
  * @typedef putResult
@@ -384,6 +414,7 @@ module.exports = LimitDBRedis;
  * @typedef getParams
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
+ * @property {configOverride} config Externally provided bucket configruation
  *
  * @typedef getResult
  * @property {integer} remaining The number of tokens remaining in the bucket.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,7 @@ const INTERVAL_TO_MS = {
 
 const INTERVAL_SHORTCUTS = Object.keys(INTERVAL_TO_MS);
 
-function normalizeType(params) {
+function normalizeTemporals(params) {
   const type = _.pick(params, [
     'per_interval',
     'interval',
@@ -32,6 +32,12 @@ function normalizeType(params) {
   if (type.per_interval) {
     type.ttl = ((type.size * type.interval) / type.per_interval) / 1000;
   }
+
+  return type;
+}
+
+function normalizeType(params) {
+  const type = normalizeTemporals(params);
 
   type.overrides = _.map(params.overrides || params.override || {}, (overrideDef, name) => {
     const override = normalizeType(overrideDef);
@@ -76,5 +82,6 @@ module.exports = {
   buildBuckets,
   buildBucket,
   INTERVAL_SHORTCUTS,
+  normalizeTemporals,
   normalizeType
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,12 +1,12 @@
-const ms     = require('ms');
-const _      = require('lodash');
-const LRU    = require('lru-cache');
+const ms = require('ms');
+const _ = require('lodash');
+const LRU = require('lru-cache');
 
 const INTERVAL_TO_MS = {
   'per_second': ms('1s'),
   'per_minute': ms('1m'),
-  'per_hour':   ms('1h'),
-  'per_day':    ms('1d')
+  'per_hour': ms('1h'),
+  'per_day': ms('1d')
 };
 
 const INTERVAL_SHORTCUTS = Object.keys(INTERVAL_TO_MS);
@@ -19,10 +19,10 @@ function normalizeType(params) {
     'unlimited'
   ]);
 
-  INTERVAL_SHORTCUTS.forEach(ish => {
-    if (!params[ish]) { return; }
-    type.interval = INTERVAL_TO_MS[ish];
-    type.per_interval = params[ish];
+  INTERVAL_SHORTCUTS.forEach(intervalShortcut => {
+    if (!params[intervalShortcut]) { return; }
+    type.interval = INTERVAL_TO_MS[intervalShortcut];
+    type.per_interval = params[intervalShortcut];
   });
 
   if (typeof type.size === 'undefined') {
@@ -72,20 +72,9 @@ function buildBucket(bucket) {
   return normalizeType(bucket);
 }
 
-class LimitdRedisValidationError extends Error {
-  constructor(msg, extra) {
-    super();
-    this.name = this.constructor.name;
-    this.message = msg;
-    Error.captureStackTrace(this, this.constructor);
-    if (extra) {
-      this.extra = extra;
-    }
-  }
-}
-
 module.exports = {
   buildBuckets,
   buildBucket,
-  LimitdRedisValidationError
+  INTERVAL_SHORTCUTS,
+  normalizeType
 };

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,64 +1,64 @@
 const { INTERVAL_SHORTCUTS } = require('./utils');
 
 class LimitdRedisValidationError extends Error {
-	constructor(msg, extra) {
-		super();
-		this.name = this.constructor.name;
-		this.message = msg;
-		Error.captureStackTrace(this, this.constructor);
-		if (extra) {
-			this.extra = extra;
-		}
-	}
+  constructor(msg, extra) {
+    super();
+    this.name = this.constructor.name;
+    this.message = msg;
+    Error.captureStackTrace(this, this.constructor);
+    if (extra) {
+      this.extra = extra;
+    }
+  }
 }
 
 function validateParams(params, buckets) {
-	if (typeof params !== 'object') {
-		return new LimitdRedisValidationError('params are required', { code: 101 });
-	}
+  if (typeof params !== 'object') {
+    return new LimitdRedisValidationError('params are required', { code: 101 });
+  }
 
-	if (typeof params.type !== 'string') {
-		return new LimitdRedisValidationError('type is required', { code: 102 });
-	}
+  if (typeof params.type !== 'string') {
+    return new LimitdRedisValidationError('type is required', { code: 102 });
+  }
 
-	if (typeof buckets[params.type] === 'undefined') {
-		return new LimitdRedisValidationError(`undefined bucket type ${params.type}`, { code: 103 });
-	}
+  if (typeof buckets[params.type] === 'undefined') {
+    return new LimitdRedisValidationError(`undefined bucket type ${params.type}`, { code: 103 });
+  }
 
-	if (typeof params.key !== 'string') {
-		return new LimitdRedisValidationError('key is required', { code: 104 });
-	}
+  if (typeof params.key !== 'string') {
+    return new LimitdRedisValidationError('key is required', { code: 104 });
+  }
 
-	if (typeof params.configOverride !== 'undefined') {
-		try {
-			validateOverride(params.configOverride);
-		} catch (error) {
-			return error;
-		}
-	}
+  if (typeof params.configOverride !== 'undefined') {
+    try {
+      validateOverride(params.configOverride);
+    } catch (error) {
+      return error;
+    }
+  }
 }
 
 function validateOverride(configOverride) {
-	if (typeof configOverride !== 'object') {
-		throw new LimitdRedisValidationError('configuration overrides must be an object', { code: 105 });
-	}
+  if (typeof configOverride !== 'object') {
+    throw new LimitdRedisValidationError('configuration overrides must be an object', { code: 105 });
+  }
 
-	// If size is provided, nothing more is strictly required
-	// (as in the case of static bucket configurations)
-	if (typeof configOverride.size === 'number') {
-		return;
-	}
+  // If size is provided, nothing more is strictly required
+  // (as in the case of static bucket configurations)
+  if (typeof configOverride.size === 'number') {
+    return;
+  }
 
-	const interval = Object.keys(configOverride)
-		.find(key => INTERVAL_SHORTCUTS.indexOf(key) > -1);
+  const interval = Object.keys(configOverride)
+    .find(key => INTERVAL_SHORTCUTS.indexOf(key) > -1);
 
-	// If size is not provided, we *must* have a interval specified
-	if (typeof interval === 'undefined') {
-		throw new LimitdRedisValidationError('configuration overrides must provide either a size or interval', { code: 106 });
-	}
+  // If size is not provided, we *must* have a interval specified
+  if (typeof interval === 'undefined') {
+    throw new LimitdRedisValidationError('configuration overrides must provide either a size or interval', { code: 106 });
+  }
 }
 
 module.exports = {
-	validateParams,
-	LimitdRedisValidationError,
+  validateParams,
+  LimitdRedisValidationError,
 };

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,0 +1,64 @@
+const { INTERVAL_SHORTCUTS } = require('./utils');
+
+class LimitdRedisValidationError extends Error {
+	constructor(msg, extra) {
+		super();
+		this.name = this.constructor.name;
+		this.message = msg;
+		Error.captureStackTrace(this, this.constructor);
+		if (extra) {
+			this.extra = extra;
+		}
+	}
+}
+
+function validateParams(params, buckets) {
+	if (typeof params !== 'object') {
+		return new LimitdRedisValidationError('params are required', { code: 101 });
+	}
+
+	if (typeof params.type !== 'string') {
+		return new LimitdRedisValidationError('type is required', { code: 102 });
+	}
+
+	if (typeof buckets[params.type] === 'undefined') {
+		return new LimitdRedisValidationError(`undefined bucket type ${params.type}`, { code: 103 });
+	}
+
+	if (typeof params.key !== 'string') {
+		return new LimitdRedisValidationError('key is required', { code: 104 });
+	}
+
+	if (typeof params.configOverride !== 'undefined') {
+		try {
+			validateOverride(params.configOverride);
+		} catch (error) {
+			return error;
+		}
+	}
+}
+
+function validateOverride(configOverride) {
+	if (typeof configOverride !== 'object') {
+		throw new LimitdRedisValidationError('configuration overrides must be an object', { code: 105 });
+	}
+
+	// If size is provided, nothing more is strictly required
+	// (as in the case of static bucket configurations)
+	if (typeof configOverride.size === 'number') {
+		return;
+	}
+
+	const interval = Object.keys(configOverride)
+		.find(key => INTERVAL_SHORTCUTS.indexOf(key) > -1);
+
+	// If size is not provided, we *must* have a interval specified
+	if (typeof interval === 'undefined') {
+		throw new LimitdRedisValidationError('configuration overrides must provide either a size or interval', { code: 106 });
+	}
+}
+
+module.exports = {
+	validateParams,
+	LimitdRedisValidationError,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd-redis",
-  "version": "5.3.0",
+  "version": "5.2.0",
   "description": "A database client for limits on top of redis",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd-redis",
-  "version": "6.0.0",
+  "version": "5.3.0",
   "description": "A database client for limits on top of redis",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd-redis",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "A database client for limits on top of redis",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd-redis",
-  "version": "5.3.0",
+  "version": "6.0.0",
   "description": "A database client for limits on top of redis",
   "main": "index.js",
   "repository": {

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -8,7 +8,7 @@ const assert   = require('chai').assert;
 const buckets = {
   ip: {
     size: 10,
-    per_second: 5,
+    per_day: 5,
     overrides: {
       '127.0.0.1': {
         per_second: 100
@@ -166,7 +166,7 @@ describe('LimitDBRedis', () => {
       });
     });
 
-    it('should return TRUE with right remaining and reset after filling up the bucket', (done) => {
+    it.only('should return TRUE with right remaining and reset after filling up the bucket', (done) => {
       const now = Date.now();
       db.take({
         type: 'ip',
@@ -397,6 +397,20 @@ describe('LimitDBRedis', () => {
         assert.ok(response.conformant);
         assert.equal(response.remaining, 0);
         assert.equal(response.limit, 10);
+        done();
+      });
+    });
+
+    it('should use config override when provided"', (done) => {
+      const configOverride = { bucketSize: 7 };
+      db.take({ type: 'ip', key: '7.7.7.7', configOverride}, (err, response) => {
+        if (err) {
+          return done(err);
+        }
+        console.log(`got response: ${JSON.stringify(response)}`);
+        assert.ok(response.conformant);
+        assert.equal(response.remaining, 6);
+        assert.equal(response.limit, 7);
         done();
       });
     });

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -608,7 +608,7 @@ describe('LimitDBRedis', () => {
         if (err) return done(err);
         db.put(bucketKey, (err) => { // restores all 4
           if (err) return done(err);
-          db.take(bucketKey, (err, response) => { // takes 1, 3 remain
+          db.take(bucketKey, (err) => { // takes 1, 3 remain
             if (err) return done(err);
             db.redis.ttl(`${bucketKey.type}:${bucketKey.key}`, (err, ttl) => {
               if (err) {
@@ -702,7 +702,7 @@ describe('LimitDBRedis', () => {
     it('should use per interval config override when provided', (done) => {
       const oneDayInMs = ms('24h');
       const configOverride = { per_day: 1 };
-      db.take({ type: 'ip', key: '7.7.7.14', configOverride }, (err, result) => {
+      db.take({ type: 'ip', key: '7.7.7.14', configOverride }, (err) => {
         if (err) {
           return done(err);
         }
@@ -779,7 +779,7 @@ describe('LimitDBRedis', () => {
           done();
         });
       });
-    })
+    });
   });
 
   describe('#resetAll', function () {

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -8,7 +8,7 @@ const assert   = require('chai').assert;
 const buckets = {
   ip: {
     size: 10,
-    per_day: 5,
+    per_second: 5,
     overrides: {
       '127.0.0.1': {
         per_second: 100
@@ -166,7 +166,7 @@ describe('LimitDBRedis', () => {
       });
     });
 
-    it.only('should return TRUE with right remaining and reset after filling up the bucket', (done) => {
+    it('should return TRUE with right remaining and reset after filling up the bucket', (done) => {
       const now = Date.now();
       db.take({
         type: 'ip',

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -90,28 +90,6 @@ describe('LimitDBRedis', () => {
     });
   });
 
-  describe('#validateParms', () => {
-    it('should fail when params are not provided', () => {
-      const err = db.validateParams();
-      assert.match(err.message, /params are required/);
-    });
-
-    it('should fail when type is not provided', () => {
-      const err = db.validateParams({});
-      assert.match(err.message, /type is required/);
-    });
-
-    it('should fail when type is not defined', () => {
-      const err = db.validateParams({ type: 'cc' });
-      assert.match(err.message, /undefined bucket type cc/);
-    });
-
-    it('should fail when key is not provided', () => {
-      const err = db.validateParams({ type: 'ip' });
-      assert.match(err.message, /key is required/);
-    });
-  });
-
   describe('#configurateBucketKey', () => {
     it('should add new bucket to existing configuration', () => {
       db.configurateBucket('test', { size: 5 });
@@ -401,8 +379,8 @@ describe('LimitDBRedis', () => {
       });
     });
 
-    it('should use bucketSize config override when provided', (done) => {
-      const configOverride = { bucketSize: 7 };
+    it('should use size config override when provided', (done) => {
+      const configOverride = { size : 7 };
       db.take({ type: 'ip', key: '7.7.7.7', configOverride}, (err, response) => {
         if (err) {
           return done(err);
@@ -414,9 +392,9 @@ describe('LimitDBRedis', () => {
       });
     });
 
-    it('should use refillRateMsPerToken config override when provided', (done) => {
+    it('should use per interval config override when provided', (done) => {
       const oneDayInMs = ms('24h');
-      const configOverride = { refillRateMsPerToken: oneDayInMs };
+      const configOverride = { per_day: 1 };
       db.take({ type: 'ip', key: '7.7.7.8', configOverride}, (err, response) => {
         if (err) {
           return done(err);
@@ -424,6 +402,40 @@ describe('LimitDBRedis', () => {
         const dayFromNow = Date.now() + oneDayInMs;
         assert.closeTo(response.reset, dayFromNow / 1000, 3);
         done();
+      });
+    });
+
+    it('should use size AND interval config override when provided', (done) => {
+      const oneDayInMs = ms('24h');
+      const configOverride = { size: 3, per_day: 1 };
+      db.take({ type: 'ip', key: '7.7.7.8', configOverride}, (err, response) => {
+        if (err) {
+          return done(err);
+        }
+        assert.ok(response.conformant);
+        assert.equal(response.remaining, 2);
+        assert.equal(response.limit, 3);
+
+        const dayFromNow = Date.now() + oneDayInMs;
+        assert.closeTo(response.reset, dayFromNow / 1000, 3);
+        done();
+      });
+    });
+
+    it('should set ttl to reflect config override', (done) => {
+      const configOverride = { per_day: 5 };
+      const params = { type: 'ip', key: '7.7.7.9', configOverride};
+      db.take(params, function (err) {
+        if (err) {
+          return done(err);
+        }
+        db.redis.ttl(`${params.type}:${params.key}`, (err, ttl) => {
+          if (err) {
+            return done(err);
+          }
+          assert.equal(ttl, 86400);
+          done();
+        });
       });
     });
   });
@@ -536,8 +548,8 @@ describe('LimitDBRedis', () => {
       });
     });
 
-    it('should use bucketSize config override when provided', (done) => {
-      const configOverride = { bucketSize: 4 };
+    it('should use size config override when provided', (done) => {
+      const configOverride = { size: 4 };
       const bucketKey = { type: 'ip',  key: '7.7.7.9', configOverride };
       db.take(Object.assign({ count: 'all' }, bucketKey), (err) => {
         if (err) return done(err);
@@ -552,10 +564,10 @@ describe('LimitDBRedis', () => {
       });
     });
 
-    it('should use bucketSize config override when provided', (done) => {
+    it('should use per interval config override when provided', (done) => {
       const oneDayInMs = ms('24h');
-      const configOverride = { refillRateMsPerToken: oneDayInMs };
-      const bucketKey = { type: 'ip',  key: '7.7.7.9', configOverride };
+      const configOverride = { per_day: 1 };
+      const bucketKey = { type: 'ip',  key: '7.7.7.10', configOverride };
       db.take(Object.assign({ count: 'all' }, bucketKey), (err) => {
         if (err) return done(err);
         db.put(bucketKey, (err) => { // restores all 4
@@ -565,6 +577,46 @@ describe('LimitDBRedis', () => {
             const dayFromNow = Date.now() + oneDayInMs;
             assert.closeTo(response.reset, dayFromNow / 1000, 3);
             done();
+          });
+        });
+      });
+    });
+
+    it('should use size AND per interval config override when provided', (done) => {
+      const oneDayInMs = ms('24h');
+      const configOverride = { size: 4, per_day: 1 };
+      const bucketKey = { type: 'ip',  key: '7.7.7.11', configOverride };
+      db.take(Object.assign({ count: 'all' }, bucketKey), (err) => {
+        if (err) return done(err);
+        db.put(bucketKey, (err) => { // restores all 4
+          if (err) return done(err);
+          db.take(bucketKey, (err, response) => { // takes 1, 3 remain
+            if (err) return done(err);
+            assert.equal(response.remaining, 3);
+            const dayFromNow = Date.now() + oneDayInMs;
+            assert.closeTo(response.reset, dayFromNow / 1000, 3);
+            done();
+          });
+        });
+      });
+    });
+
+    it('should set ttl to reflect config override', (done) => {
+      const configOverride = { per_day: 5 };
+      const bucketKey = { type: 'ip', key: '7.7.7.12', configOverride};
+      db.take(Object.assign({ count: 'all' }, bucketKey), (err) => {
+        if (err) return done(err);
+        db.put(bucketKey, (err) => { // restores all 4
+          if (err) return done(err);
+          db.take(bucketKey, (err, response) => { // takes 1, 3 remain
+            if (err) return done(err);
+            db.redis.ttl(`${bucketKey.type}:${bucketKey.key}`, (err, ttl) => {
+              if (err) {
+                return done(err);
+              }
+              assert.equal(ttl, 86400);
+              done();
+            });
           });
         });
       });
@@ -635,9 +687,9 @@ describe('LimitDBRedis', () => {
       });
     });
 
-    it('should use bucketSize config override when provided', (done) => {
-      const configOverride = { bucketSize: 7 };
-      db.get({type: 'ip', key: '7.7.7.10', configOverride}, (err, result) => {
+    it('should use size config override when provided', (done) => {
+      const configOverride = { size: 7 };
+      db.get({type: 'ip', key: '7.7.7.13', configOverride}, (err, result) => {
         if (err) {
           return done(err);
         }
@@ -647,14 +699,14 @@ describe('LimitDBRedis', () => {
       });
     });
 
-    it('should use refillRateMsPerToken config override when provided', (done) => {
+    it('should use per interval config override when provided', (done) => {
       const oneDayInMs = ms('24h');
-      const configOverride = { refillRateMsPerToken: oneDayInMs };
-      db.take({ type: 'ip', key: '7.7.7.11', configOverride }, (err, result) => {
+      const configOverride = { per_day: 1 };
+      db.take({ type: 'ip', key: '7.7.7.14', configOverride }, (err, result) => {
         if (err) {
           return done(err);
         }
-        db.get({ type: 'ip', key: '7.7.7.11', configOverride }, (err, result) => {
+        db.get({ type: 'ip', key: '7.7.7.14', configOverride }, (err, result) => {
           if (err) {
             return done(err);
           }
@@ -702,9 +754,9 @@ describe('LimitDBRedis', () => {
       });
     });
 
-    it('should use refillRateMsPerToken config override when provided', (done) => {
-      const oneSecondInMs = ms('1s');
-      const configOverride = { refillRateMsPerToken: oneSecondInMs };
+    it('should use per interval config override when provided', (done) => {
+      const oneSecondInMs = ms('1s') / 3;
+      const configOverride = { per_second: 3, size: 10 };
       db.take({
         type: 'ip',
         key: '211.76.23.6',

--- a/test/validation.tests.js
+++ b/test/validation.tests.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const assert = require('chai').assert;
+
+const { validateParams } = require('../lib/validation');
+
+describe('validation', () => {
+	describe('validateParameters', () => {
+
+		const buckets = {
+			user: {
+				size: 10
+			}
+		};
+
+		describe('when providing invalid parameters', () => {
+			const invalidParameterSets = [
+				{
+					result: {
+						message: 'params are required',
+						code: 101
+					}
+				}, {
+					params: {},
+					result: {
+						message: 'type is required',
+						code: 102
+					}
+				}, {
+					params: {
+						type: 'ip'
+					},
+					result: {
+						message: 'undefined bucket type ip',
+						code: 103
+					}
+				}, {
+					params: {
+						type: 'user'
+					},
+					result: {
+						message: 'key is required',
+						code: 104
+					}
+				}, {
+					params: {
+						type: 'user',
+						key: 'tenant|username',
+						configOverride: 5
+					},
+					result: {
+						message: 'configuration overrides must be an object',
+						code: 105
+					}
+				}, {
+					params: {
+						type: 'user',
+						key: 'tenant|username',
+						configOverride: {}
+					},
+					result: {
+						message: 'configuration overrides must provide either a size or interval',
+						code: 106
+					}
+				}
+			]
+
+			invalidParameterSets.forEach(testcase => {
+				it(`Should return a validation error, code ${testcase.result.code}`, () => {
+					const result = validateParams(testcase.params, buckets);
+					assert.strictEqual(result.name, 'LimitdRedisValidationError');
+					assert.strictEqual(result.message, testcase.result.message);
+					assert.deepEqual(result.extra, { code: testcase.result.code });
+					assert.exists(result.stack);
+				})
+			})
+		});
+
+		describe('when providing valid parameters', () => {
+			const validParameterSerts = [
+				{
+					params: {
+						type: 'user',
+						key: 'tenant|username',
+					},
+					name: 'type and key params'
+				}, {
+					params: {
+						type: 'user',
+						key: 'tenant|username',
+						configOverride: {
+							size: 77
+						}
+					},
+					name: 'configOverride with size'
+				}, {
+					params: {
+						type: 'user',
+						key: 'tenant|username',
+						configOverride: {
+							per_hour: 300
+						}
+					},
+					name: 'configOverride with interval'
+				}, {
+					params: {
+						type: 'user',
+						key: 'tenant|username',
+						configOverride: {
+							size: 30,
+							per_hour: 300
+						}
+					},
+					name: 'configOverride with size and interval'
+				},
+			]
+
+			validParameterSerts.forEach(testcase => {
+				it(`Should not cause a validation error for ${testcase.name}`, () => {
+					const result = validateParams(testcase.params, buckets);
+					assert.isUndefined(result);
+				})
+			})
+		});
+	})
+});

--- a/test/validation.tests.js
+++ b/test/validation.tests.js
@@ -1,126 +1,124 @@
-'use strict';
-
 const assert = require('chai').assert;
 
 const { validateParams } = require('../lib/validation');
 
 describe('validation', () => {
-	describe('validateParameters', () => {
+  describe('validateParameters', () => {
 
-		const buckets = {
-			user: {
-				size: 10
-			}
-		};
+    const buckets = {
+      user: {
+        size: 10
+      }
+    };
 
-		describe('when providing invalid parameters', () => {
-			const invalidParameterSets = [
-				{
-					result: {
-						message: 'params are required',
-						code: 101
-					}
-				}, {
-					params: {},
-					result: {
-						message: 'type is required',
-						code: 102
-					}
-				}, {
-					params: {
-						type: 'ip'
-					},
-					result: {
-						message: 'undefined bucket type ip',
-						code: 103
-					}
-				}, {
-					params: {
-						type: 'user'
-					},
-					result: {
-						message: 'key is required',
-						code: 104
-					}
-				}, {
-					params: {
-						type: 'user',
-						key: 'tenant|username',
-						configOverride: 5
-					},
-					result: {
-						message: 'configuration overrides must be an object',
-						code: 105
-					}
-				}, {
-					params: {
-						type: 'user',
-						key: 'tenant|username',
-						configOverride: {}
-					},
-					result: {
-						message: 'configuration overrides must provide either a size or interval',
-						code: 106
-					}
-				}
-			]
+    describe('when providing invalid parameters', () => {
+      const invalidParameterSets = [
+        {
+          result: {
+            message: 'params are required',
+            code: 101
+          }
+        }, {
+          params: {},
+          result: {
+            message: 'type is required',
+            code: 102
+          }
+        }, {
+          params: {
+            type: 'ip'
+          },
+          result: {
+            message: 'undefined bucket type ip',
+            code: 103
+          }
+        }, {
+          params: {
+            type: 'user'
+          },
+          result: {
+            message: 'key is required',
+            code: 104
+          }
+        }, {
+          params: {
+            type: 'user',
+            key: 'tenant|username',
+            configOverride: 5
+          },
+          result: {
+            message: 'configuration overrides must be an object',
+            code: 105
+          }
+        }, {
+          params: {
+            type: 'user',
+            key: 'tenant|username',
+            configOverride: {}
+          },
+          result: {
+            message: 'configuration overrides must provide either a size or interval',
+            code: 106
+          }
+        }
+      ];
 
-			invalidParameterSets.forEach(testcase => {
-				it(`Should return a validation error, code ${testcase.result.code}`, () => {
-					const result = validateParams(testcase.params, buckets);
-					assert.strictEqual(result.name, 'LimitdRedisValidationError');
-					assert.strictEqual(result.message, testcase.result.message);
-					assert.deepEqual(result.extra, { code: testcase.result.code });
-					assert.exists(result.stack);
-				})
-			})
-		});
+      invalidParameterSets.forEach(testcase => {
+        it(`Should return a validation error, code ${testcase.result.code}`, () => {
+          const result = validateParams(testcase.params, buckets);
+          assert.strictEqual(result.name, 'LimitdRedisValidationError');
+          assert.strictEqual(result.message, testcase.result.message);
+          assert.deepEqual(result.extra, { code: testcase.result.code });
+          assert.exists(result.stack);
+        });
+      });
+    });
 
-		describe('when providing valid parameters', () => {
-			const validParameterSerts = [
-				{
-					params: {
-						type: 'user',
-						key: 'tenant|username',
-					},
-					name: 'type and key params'
-				}, {
-					params: {
-						type: 'user',
-						key: 'tenant|username',
-						configOverride: {
-							size: 77
-						}
-					},
-					name: 'configOverride with size'
-				}, {
-					params: {
-						type: 'user',
-						key: 'tenant|username',
-						configOverride: {
-							per_hour: 300
-						}
-					},
-					name: 'configOverride with interval'
-				}, {
-					params: {
-						type: 'user',
-						key: 'tenant|username',
-						configOverride: {
-							size: 30,
-							per_hour: 300
-						}
-					},
-					name: 'configOverride with size and interval'
-				},
-			]
+    describe('when providing valid parameters', () => {
+      const validParameterSerts = [
+        {
+          params: {
+            type: 'user',
+            key: 'tenant|username',
+          },
+          name: 'type and key params'
+        }, {
+          params: {
+            type: 'user',
+            key: 'tenant|username',
+            configOverride: {
+              size: 77
+            }
+          },
+          name: 'configOverride with size'
+        }, {
+          params: {
+            type: 'user',
+            key: 'tenant|username',
+            configOverride: {
+              per_hour: 300
+            }
+          },
+          name: 'configOverride with interval'
+        }, {
+          params: {
+            type: 'user',
+            key: 'tenant|username',
+            configOverride: {
+              size: 30,
+              per_hour: 300
+            }
+          },
+          name: 'configOverride with size and interval'
+        },
+      ];
 
-			validParameterSerts.forEach(testcase => {
-				it(`Should not cause a validation error for ${testcase.name}`, () => {
-					const result = validateParams(testcase.params, buckets);
-					assert.isUndefined(result);
-				})
-			})
-		});
-	})
+      validParameterSerts.forEach(testcase => {
+        it(`Should not cause a validation error for ${testcase.name}`, () => {
+          const result = validateParams(testcase.params, buckets);
+          assert.isUndefined(result);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Description

Per slack thread, we need a way for tenants to be able to customize Suspicious IP Throttling rates.  Since the existing `DynamicClientConfigurationProxy` + MongoDB store will not scale, we're passing in bucket configuration at runtime.

One big downside to this approach: if the caller(s) do not all retrieve tenant settings and pass them in appropriately, then we will get mixed results.  For instance, if a user gets blocked from auth0-server where a tenant override is passed in to a `take` operation, it's possible that the same user will not show up in API2 as blocked if API2 does not retrieve and pass in the same tenant settings to its `get` operation.  Can try to mitigate with wrappers/enhancements, but it's less-than-ideal.

### References

- https://auth0.slack.com/archives/C01J73CL4A3/p1627656818000500?thread_ts=1617984121.012400&cid=C01J73CL4A3
- https://auth0team.atlassian.net/browse/CAUTH-954

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
