### PR TITLE
feat: Add #getClient methods to retrieve the Redis client

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -128,6 +128,10 @@ class LimitdRedis extends EventEmitter {
       callback(err);
     });
   }
+
+  getClient() {
+    return this.db.getClient();
+  }
 }
 
 module.exports = LimitdRedis;

--- a/lib/db.js
+++ b/lib/db.js
@@ -321,6 +321,10 @@ class LimitDBRedis extends EventEmitter {
       db.flushdb(cb);
     }, callback);
   }
+
+  getClient() {
+    return this.redis;
+  }
 }
 
 

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -1,6 +1,7 @@
 /* eslint-env node, mocha */
 const _ = require('lodash');
 const assert = require('chai').assert;
+const Redis = require('ioredis');
 const LimitRedis = require('../lib/client');
 const ValidationError = LimitRedis.ValidationError;
 
@@ -189,6 +190,12 @@ describe('LimitdRedis', () => {
         assert.equal(client.db.listenerCount('ready'), 0);
         done(err);
       });
+    });
+  });
+
+  describe('#getClient', () => {
+    it('should be instanceof Redis', () => {
+      assert.instanceOf(client.getClient(), Redis);
     });
   });
 });

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -4,6 +4,7 @@ const async    = require('async');
 const _        = require('lodash');
 const LimitDB  = require('../lib/db');
 const assert   = require('chai').assert;
+const Redis    = require('ioredis');
 
 const buckets = {
   ip: {
@@ -854,6 +855,12 @@ describe('LimitDBRedis', () => {
           });
         });
       });
+    });
+  });
+
+  describe('#getClient', () => {
+    it('should be instanceof Redis', () => {
+      assert.instanceOf(db.getClient(), Redis);
     });
   });
 });


### PR DESCRIPTION
### Description

Add #getClient methods to retrieve the Redis client. We need the redis client object to meet the API exposed by health checks.

### References

[IAMRISK-1386]

### Testing

`npm test`

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`


[IAMRISK-1386]: https://auth0team.atlassian.net/browse/IAMRISK-1386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ