### PR TITLE
[IAMRISK-1454] check for non integer count

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -150,14 +150,11 @@ class LimitDBRedis extends EventEmitter {
     const bucket = this.buckets[params.type];
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
-    if (params.count && params.count !== 'all' && !Number.isInteger(params.count)) {
-      throw new Error('if provided, count must be \'all\' or an integer value');
-    }
-
-    let count = (params.count || params.count === 0) ? params.count : 1;
-    if (count === 'all') {
-      count = bucketKeyConfig.size;
-    }
+    const count = this._determineCount({
+      paramsCount: params.count,
+      defaultCount: 1,
+      bucketKeyConfigSize: bucketKeyConfig.size,
+    });
 
     if (bucketKeyConfig.unlimited) {
       return process.nextTick(callback, null, {
@@ -238,15 +235,13 @@ class LimitDBRedis extends EventEmitter {
     const bucket = this.buckets[params.type];
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
-    if (params.count && params.count !== 'all' && !Number.isInteger(params.count)) {
-      throw new Error('if provided, count must be \'all\' or an integer value');
-    }
-
-    let count = (params.count || params.count === 0) ? params.count : 'all';
-    if (count === 'all') {
-      count = bucketKeyConfig.size;
-    }
-    count = Math.min(count, bucketKeyConfig.size);
+    const count = Math.min(
+      this._determineCount({
+        paramsCount: params.count,
+        defaultCount: bucketKeyConfig.size,
+        bucketKeyConfigSize: bucketKeyConfig.size,
+      }),
+      bucketKeyConfig.size);
 
     if (bucketKeyConfig.unlimited) {
       return process.nextTick(callback, null, {
@@ -328,6 +323,22 @@ class LimitDBRedis extends EventEmitter {
     async.each(dbs, (db, cb) => {
       db.flushdb(cb);
     }, callback);
+  }
+
+  _determineCount({paramsCount, defaultCount, bucketKeyConfigSize}) {
+    if (paramsCount === 'all') {
+      return bucketKeyConfigSize;
+    }
+
+    if (Number.isInteger(paramsCount)) {
+      return paramsCount;
+    }
+
+    if (!paramsCount) {
+      return defaultCount;
+    }
+
+    throw new Error('if provided, count must be \'all\' or an integer value');
   }
 }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -150,6 +150,10 @@ class LimitDBRedis extends EventEmitter {
     const bucket = this.buckets[params.type];
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
+    if (params.count && params.count !== 'all' && !Number.isInteger(params.count)) {
+      throw new Error('if provided, count must be \'all\' or an integer value');
+    }
+
     let count = (params.count || params.count === 0) ? params.count : 1;
     if (count === 'all') {
       count = bucketKeyConfig.size;
@@ -233,6 +237,10 @@ class LimitDBRedis extends EventEmitter {
 
     const bucket = this.buckets[params.type];
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
+
+    if (params.count && params.count !== 'all' && !Number.isInteger(params.count)) {
+      throw new Error('if provided, count must be \'all\' or an integer value');
+    }
 
     let count = (params.count || params.count === 0) ? params.count : 'all';
     if (count === 'all') {

--- a/lib/db.js
+++ b/lib/db.js
@@ -150,11 +150,9 @@ class LimitDBRedis extends EventEmitter {
     const bucket = this.buckets[params.type];
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
-    let count = 1;
-    if (params.count === 'all') {
+    let count = params.count || params.count === 0 ? params.count : 1;
+    if (count === 'all') {
       count = bucketKeyConfig.size;
-    } else if (Number.isInteger(params.count)) {
-      count = params.count;
     }
 
     if (bucketKeyConfig.unlimited) {
@@ -236,9 +234,9 @@ class LimitDBRedis extends EventEmitter {
     const bucket = this.buckets[params.type];
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
-    let count = bucketKeyConfig.size;
-    if (Number.isInteger(params.count)) {
-      count = params.count;
+    let count = params.count || params.count === 0 ? params.count : 'all';
+    if (count === 'all') {
+      count = bucketKeyConfig.size;
     }
     count = Math.min(count, bucketKeyConfig.size);
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -150,9 +150,11 @@ class LimitDBRedis extends EventEmitter {
     const bucket = this.buckets[params.type];
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
-    let count = params.count || 1;
-    if (count === 'all') {
+    let count = 1;
+    if (params.count === 'all') {
       count = bucketKeyConfig.size;
+    } else if (Number.isInteger(params.count)) {
+      count = params.count;
     }
 
     if (bucketKeyConfig.unlimited) {
@@ -234,9 +236,9 @@ class LimitDBRedis extends EventEmitter {
     const bucket = this.buckets[params.type];
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
-    let count = params.count || 'all';
-    if (count === 'all') {
-      count = bucketKeyConfig.size;
+    let count = bucketKeyConfig.size;
+    if (Number.isInteger(params.count)) {
+      count = params.count;
     }
     count = Math.min(count, bucketKeyConfig.size);
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -150,7 +150,7 @@ class LimitDBRedis extends EventEmitter {
     const bucket = this.buckets[params.type];
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
-    let count = params.count || params.count === 0 ? params.count : 1;
+    let count = (params.count || params.count === 0) ? params.count : 1;
     if (count === 'all') {
       count = bucketKeyConfig.size;
     }
@@ -234,7 +234,7 @@ class LimitDBRedis extends EventEmitter {
     const bucket = this.buckets[params.type];
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
-    let count = params.count || params.count === 0 ? params.count : 'all';
+    let count = (params.count || params.count === 0) ? params.count : 'all';
     if (count === 'all') {
       count = bucketKeyConfig.size;
     }

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -35,7 +35,10 @@ const buckets = {
       },
       '8.8.8.8': {
         size: 10
-      }
+      },
+      '9.8.7.6': {
+        size: 200,
+      },
     }
   },
   user: {
@@ -383,6 +386,18 @@ describe('LimitDBRedis', () => {
       });
     });
 
+    it('should work with count=0', (done) => {
+      db.take({ type: 'ip', key: '9.8.7.6', count: 0 }, (err, response) => {
+        if (err) {
+          return done(err);
+        }
+        assert.ok(response.conformant);
+        assert.equal(response.remaining, 200);
+        assert.equal(response.limit, 200);
+        done();
+      });
+    });
+
     it('should use size config override when provided', (done) => {
       const configOverride = { size : 7 };
       db.take({ type: 'ip', key: '7.7.7.7', configOverride}, (err, response) => {
@@ -537,6 +552,21 @@ describe('LimitDBRedis', () => {
             if (err) return done(err);
             assert.equal(response.conformant, true);
             assert.equal(response.remaining, 1);
+            done();
+          });
+        });
+      });
+    });
+
+    it('should restore nothing when count=0', (done) => {
+      db.take({ type: 'ip',  key: '9.8.7.6', count: 123 }, (err) => {
+        if (err) return done(err);
+        db.put({ type: 'ip', key: '9.8.7.6', count: 0 }, (err) => {
+          if (err) return done(err);
+          db.take({ type: 'ip',  key: '9.8.7.6', count: 0 }, (err, response) => {
+            if (err) return done(err);
+            assert.equal(response.conformant, true);
+            assert.equal(response.remaining, 77);
             done();
           });
         });
@@ -790,6 +820,30 @@ describe('LimitDBRedis', () => {
         });
       });
     });
+
+    it('should not be delayed when traffic is non conformant and count=0', (done) => {
+      db.take({
+        type: 'ip',
+        key: '211.76.23.5',
+        count: 10
+      }, (err) => {
+        if (err) return done(err);
+        const waitingSince = Date.now();
+        db.wait({
+          type: 'ip',
+          key: '211.76.23.5',
+          count: 0
+        }, (err, response) => {
+          if (err) { return done(err); }
+          var waited = Date.now() - waitingSince;
+          assert.ok(response.conformant);
+          assert.notOk(response.delayed);
+          assert.closeTo(waited, 0, 20);
+          done();
+        });
+      });
+    });
+
 
     it('should use per interval config override when provided', (done) => {
       const oneSecondInMs = ms('1s') / 3;

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -398,6 +398,26 @@ describe('LimitDBRedis', () => {
       });
     });
 
+    [
+      '0',
+      0.5,
+      'ALL',
+      true,
+      1n,
+      {},
+    ].forEach((count) => {
+      it(`should not work for non-integer count=${count}`, (done) => {
+        const opts = {
+          type: 'ip',
+          key: '9.8.7.6',
+          count,
+        };
+
+        assert.throws(() => db.take(opts, () => {}), /if provided, count must be 'all' or an integer value/);
+        done();
+      });
+    });
+
     it('should use size config override when provided', (done) => {
       const configOverride = { size : 7 };
       db.take({ type: 'ip', key: '7.7.7.7', configOverride}, (err, response) => {
@@ -570,6 +590,26 @@ describe('LimitDBRedis', () => {
             done();
           });
         });
+      });
+    });
+
+    [
+      '0',
+      0.5,
+      'ALL',
+      true,
+      1n,
+      {},
+    ].forEach((count) => {
+      it(`should not work for non-integer count=${count}`, (done) => {
+        const opts = {
+          type: 'ip',
+          key: '9.8.7.6',
+          count,
+        };
+
+        assert.throws(() => db.put(opts, () => {}), /if provided, count must be 'all' or an integer value/);
+        done();
       });
     });
 


### PR DESCRIPTION

### Description

Check for non integer count, with a fast-fail for invalid counts (such as '1', 0.5, etc). 

### References

[IAMRISK-1454]

### Testing

`npm test`

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`


[IAMRISK-1454]: https://auth0team.atlassian.net/browse/IAMRISK-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ