### PR TITLE
IAMRISK-1455 fix(put): keep full bucket when already full

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ typings/
 
 # End of https://www.gitignore.io/api/node
 .vscode
+.idea
 
 # Profiler
 *.0x

--- a/lib/put.lua
+++ b/lib/put.lua
@@ -5,14 +5,12 @@ local ttl                  = tonumber(ARGV[3])
 local current_time = redis.call('TIME')
 local current_timestamp_ms = current_time[1] * 1000 + current_time[2] / 1000
 
-local current = redis.call('HMGET', KEYS[1], 'r')
-local new_content
-
-if current[1] then
-  new_content = math.min(current[1] + tokens_to_add, bucket_size)
-else
-  new_content = math.min(bucket_size + tokens_to_add, bucket_size)
+local current_remaining = redis.call('HMGET', KEYS[1], 'r')[1]
+if current_remaining == false then
+  current_remaining = bucket_size
 end
+
+local new_content = math.min(current_remaining + tokens_to_add, bucket_size)
 
 redis.replicate_commands()
 if new_content < bucket_size then

--- a/lib/put.lua
+++ b/lib/put.lua
@@ -6,19 +6,22 @@ local current_time = redis.call('TIME')
 local current_timestamp_ms = current_time[1] * 1000 + current_time[2] / 1000
 
 local current = redis.call('HMGET', KEYS[1], 'r')
+local new_content
 
 if current[1] then
-  tokens_to_add = math.min(current[1] + tokens_to_add, bucket_size)
+  new_content = math.min(current[1] + tokens_to_add, bucket_size)
+else
+  new_content = math.min(bucket_size + tokens_to_add, bucket_size)
 end
 
 redis.replicate_commands()
-if tokens_to_add < bucket_size then
+if new_content < bucket_size then
   redis.call('HMSET', KEYS[1],
             'd', current_timestamp_ms,
-            'r', tokens_to_add)
+            'r', new_content)
   redis.call('EXPIRE', KEYS[1], ttl)
 else
   redis.call('DEL', KEYS[1])
 end
 
-return { tokens_to_add, current_timestamp_ms }
+return { new_content, current_timestamp_ms }


### PR DESCRIPTION
### Description

When Redis does not hold a certain entry for a given key, we consider that this entry's bucket is full. Currently, if we call `put(count=n)` for this entry, the end result is a bucket with `n` tokens, but the we should actually just leave the bucket as is (full).

In this PR, I'm fixing this faulty behavior, by ensuring that calling `put()` over a full bucket results in a full bucket. It's quite a big change of behavior for the `put()` operation, might even be semver breaking, but arguably the older behavior is quite unexpected and I would be surprised that consumers rely on it. Would appreciate thoughts from the maintainers about this 🙇 

### References

https://auth0team.atlassian.net/browse/IAMRISK-1455

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
