### PR TITLE
PSERV-1561 - Reconnect when readonly error is received from redis in Limitr client

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -41,7 +41,7 @@ class LimitDBRedis extends EventEmitter {
         // will force a reconnect when error starts with `READONLY`
         // this code is only triggered when auto-failover is disabled
         // more: https://github.com/luin/ioredis#reconnect-on-error
-        return err.message.indexOf('READONLY') === 0;
+        return err.message.includes('READONLY');
       },
     };
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -36,7 +36,13 @@ class LimitDBRedis extends EventEmitter {
       enableOfflineQueue: false,
       keyPrefix: config.prefix,
       password: config.password,
-      tls: config.tls
+      tls: config.tls,
+      reconnectOnError: (err) => {
+        // will force a reconnect when error starts with `READONLY`
+        // this code is only triggered when auto-failover is disabled
+        // more: https://github.com/luin/ioredis#reconnect-on-error
+        return err.message.indexOf('READONLY') === 0;
+      },
     };
 
     const clusterOptions = {
@@ -325,7 +331,7 @@ class LimitDBRedis extends EventEmitter {
     }, callback);
   }
 
-  _determineCount({paramsCount, defaultCount, bucketKeyConfigSize}) {
+  _determineCount({ paramsCount, defaultCount, bucketKeyConfigSize }) {
     if (paramsCount === 'all') {
       return bucketKeyConfigSize;
     }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "disyuntor": "^3.5.0",
-    "ioredis": "^4.5.1",
+    "ioredis": "^4.28.5",
     "lodash": "^4.17.15",
     "lru-cache": "^4.1.5",
     "ms": "^2.1.2",


### PR DESCRIPTION
### Description

Adding a `reconnectOnError` handler for ioredis client that will reconnect if an error is emitted from the client that includes `READONLY` in the message.
This is important for environments where auto failover is not enabled to minimize incidents in limitr use cases when a failover does occur with an elasticache cluster.

This mimics the behavior used in `belgrano`.


### References

https://auth0team.atlassian.net/browse/PSERV-1561
https://github.com/auth0/belgrano/blob/62589d1e1d31ed5e91ea92a68c8a9b4da5fffc23/lib/cache/redis.js#L58-L63
https://github.com/luin/ioredis#reconnect-on-error

### Testing


- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
