### PR TITLE
feat:Allow to ping redis at app level and reconnect if it fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ Buckets:
 
 Ping:
 
-- `enabled` (boolean): determines if the ping functionality is enabled or not. Default: false.
+- `enabled` (function()=>boolean): function that returns whether the ping functionality is enabled or not. Default: () => false.
 - `interval` (number): represents the time between two consecutive pings. Default: 1000.
 - `maxFailedAttempts` (number): is the allowed number of failed pings before declaring the connection as dead. Default: 5.
 - `reconnectIfFailed` (boolean): indicates whether we should try to reconnect is the connection is declared dead. Default: true.
 - `maxFailedAttemptsToRetryReconnect` (number): represents the number of failed pings before firing another reconnect attempt. Default: 10.
+- `msBetweenEnabledChecks` (number): when ping is disabled, this represents the interval between two consecutive ping.enabled() checks. Default: 1000.
 
 You can also define your rates using `per_second`, `per_minute`, `per_hour`, `per_day`. So `per_second: 1` is equivalent to `per_interval: 1, interval: 1000`.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ const limitd = new Limitd({
       per_second: 5
     }
   },
-  prefix: 'test:'
+  prefix: 'test:',
+  ping: {
+    enabled: true,
+    interval: 1000,
+    maxFailedAttempts: 5,
+    reconnectIfFailed: true
+  }
 });
 ```
 
@@ -39,6 +45,7 @@ Options available:
 - `nodes` (array): [Redis Cluster Configuration](https://github.com/luin/ioredis#cluster).
 - `buckets` (object): Setup your bucket types.
 - `prefix` (string): Prefix keys in Redis.
+- `ping` (object): Configure ping to Redis DB.
 
 Buckets:
 
@@ -46,6 +53,13 @@ Buckets:
 - `per_interval` (number): is the amount of tokens that the bucket receive on every interval.
 - `interval` (number): defines the interval in milliseconds.
 - `unlimited` (boolean = false): unlimited requests (skip take).
+
+Ping:
+
+- `enabled` (boolean): determines if the ping functionality is enabled or not. Default: false.
+- `interval` (number): represents the time between two consecutive pings. Default: 1000.
+- `maxFailedAttempts` (number): is the allowed number of failed pings before declaring the connection as dead. Default: 5.
+- `reconnectIfFailed` (boolean): indicates whether we should try to reconnect is the connection is declared dead. Default: true.
 
 You can also define your rates using `per_second`, `per_minute`, `per_hour`, `per_day`. So `per_second: 1` is equivalent to `per_interval: 1, interval: 1000`.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ const limitd = new Limitd({
   },
   prefix: 'test:',
   ping: {
-    enabled: true,
     interval: 1000,
     maxFailedAttempts: 5,
     reconnectIfFailed: true
@@ -56,12 +55,9 @@ Buckets:
 
 Ping:
 
-- `enabled` (function()=>boolean): function that returns whether the ping functionality is enabled or not. Default: () => false.
-- `interval` (number): represents the time between two consecutive pings. Default: 1000.
+- `interval` (number): represents the time between two consecutive pings. Default: 3000.
 - `maxFailedAttempts` (number): is the allowed number of failed pings before declaring the connection as dead. Default: 5.
 - `reconnectIfFailed` (boolean): indicates whether we should try to reconnect is the connection is declared dead. Default: true.
-- `maxFailedAttemptsToRetryReconnect` (number): represents the number of failed pings before firing another reconnect attempt. Default: 10.
-- `msBetweenEnabledChecks` (number): when ping is disabled, this represents the interval between two consecutive ping.enabled() checks. Default: 1000.
 
 You can also define your rates using `per_second`, `per_minute`, `per_hour`, `per_day`. So `per_second: 1` is equivalent to `per_interval: 1, interval: 1000`.
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Ping:
 - `interval` (number): represents the time between two consecutive pings. Default: 1000.
 - `maxFailedAttempts` (number): is the allowed number of failed pings before declaring the connection as dead. Default: 5.
 - `reconnectIfFailed` (boolean): indicates whether we should try to reconnect is the connection is declared dead. Default: true.
+- `maxFailedAttemptsToRetryReconnect` (number): represents the number of failed pings before firing another reconnect attempt. Default: 10.
 
 You can also define your rates using `per_second`, `per_minute`, `per_hour`, `per_day`. So `per_second: 1` is equivalent to `per_interval: 1, interval: 1000`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,3 +4,8 @@ services:
     command: --save "" --appendonly no
     ports:
       - "6379:6379"
+  toxiproxy:
+    image: 'shopify/toxiproxy'
+    ports:
+      - "8474:8474"
+      - "22222:22222"

--- a/lib/client.js
+++ b/lib/client.js
@@ -29,7 +29,7 @@ class LimitdRedis extends EventEmitter {
   constructor(params) {
     super();
 
-    this.db = new LimitDBRedis(_.pick(params, ['uri', 'nodes', 'buckets', 'prefix', 'slotsRefreshTimeout', 'slotsRefreshInterval', 'password', 'tls', 'dnsLookup', 'globalTTL']));
+    this.db = new LimitDBRedis(_.pick(params, ['uri', 'nodes', 'buckets', 'prefix', 'slotsRefreshTimeout', 'slotsRefreshInterval', 'password', 'tls', 'dnsLookup', 'globalTTL', 'ping']));
 
     this.db.on('error', (err) => {
       this.emit('error', err);

--- a/lib/db.js
+++ b/lib/db.js
@@ -59,7 +59,7 @@ class LimitDBRedis extends EventEmitter {
       interval: config.ping?.interval || 1000,
       maxFailedAttempts: config.ping?.maxFailedAttempts || 5,
       reconnectIfFailed: config.ping?.reconnectIfFailed || false,
-      maxFailedAttemptsToRetryReconnect: 10
+      maxFailedAttemptsToRetryReconnect: config.ping?.maxFailedAttemptsToRetryReconnect || 10
     }
 
     this.redis = null;

--- a/lib/db.js
+++ b/lib/db.js
@@ -124,7 +124,6 @@ class LimitDBRedis extends EventEmitter {
 
   close(callback) {
     this.#stopPing();
-    this.redis.removeAllListeners();
     this.redis.quit(callback);
   }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -13,11 +13,13 @@ const PUT_LUA = fs.readFileSync(`${__dirname}/put.lua`, 'utf8');
 const PING_SUCCESS = "successful"
 const PING_ERROR = "error"
 const PING_RECONNECT = "reconnect"
+const PING_RECONNECT_DRY_RUN = "reconnect-dry-run"
 
 class LimitDBRedis extends EventEmitter {
   static get PING_SUCCESS () { return PING_SUCCESS };
   static get PING_ERROR () { return PING_ERROR };
   static get PING_RECONNECT () { return PING_RECONNECT };
+  static get PING_RECONNECT_DRY_RUN () { return PING_RECONNECT_DRY_RUN };
 
   /**
    * Creates an instance of LimitDB client for Redis.
@@ -65,7 +67,7 @@ class LimitDBRedis extends EventEmitter {
       enabled: utils.functionOrFalse(config.ping?.enabled) || (() => false),
       interval: config.ping?.interval || 1000,
       maxFailedAttempts: config.ping?.maxFailedAttempts || 5,
-      reconnectIfFailed: config.ping?.reconnectIfFailed || false,
+      reconnectIfFailed: utils.functionOrFalse(config.ping?.reconnectIfFailed) || (() => false),
       maxFailedAttemptsToRetryReconnect: config.ping?.maxFailedAttemptsToRetryReconnect || 10,
       msBetweenEnabledChecks: config.ping?.msBetweenEnabledChecks || 1000
     }
@@ -115,47 +117,49 @@ class LimitDBRedis extends EventEmitter {
         setTimeout(doPing, this.pingConfig.msBetweenEnabledChecks);
         return;
       }
-      let hrstart = process.hrtime();
+      let start = Date.now();
       this.redis.ping((err) => {
-        let hrend = process.hrtime(hrstart);
-        let duration = hrend[0]*1000 + hrend[1]/1000000;
-        (err ? this.#pingKO(err, duration) : this.#pingOK(duration)).then(() => {
-          if(this.keepPingRunning) {
-            this.pingIntervalId = setTimeout(doPing, this.pingConfig.interval);
-          }
-        });
+        let duration = Date.now()-start;
+        err ? this.#pingKO(triggerLoop, err, duration) : this.#pingOK(triggerLoop, duration)
       });
+    }
+
+    const triggerLoop = () => {
+      if(this.keepPingRunning) {
+        this.pingIntervalId = setTimeout(doPing, this.pingConfig.interval);
+      }
     }
 
     doPing();
   }
 
-  #pingOK(duration) {
-    return new Promise((res) => {
-      this.reconnecting = false
-      this.failedPings = 0;
-      this.#emitPingResult(PING_SUCCESS, undefined, duration, 0)
-      res();
-    })
+  #pingOK(callback, duration) {
+    this.reconnecting = false
+    this.failedPings = 0;
+    this.#emitPingResult(PING_SUCCESS, undefined, duration, 0)
+    callback();
   }
 
-  #pingKO(err, duration) {
-    return new Promise((res) => {
-      this.failedPings++;
-      this.#emitPingResult(PING_ERROR, err, duration, this.failedPings)
+  #pingKO(callback, err, duration) {
+    this.failedPings++;
+    this.#emitPingResult(PING_ERROR, err, duration, this.failedPings)
 
-      if (this.failedPings >= this.pingConfig.maxFailedAttempts && this.pingConfig.reconnectIfFailed && 
-          (!this.reconnecting || this.failedPings % this.pingConfig.maxFailedAttemptsToRetryReconnect == 0)) {
-        this.reconnecting = true
-        this.#retryStrategy(() => {
-          this.redis.disconnect(true);
-          this.#emitPingResult(PING_RECONNECT, undefined, 0, this.failedPings)
-          res()
-        })
-      } else {
-        res()
-      }
-    })
+    if (this.failedPings >= this.pingConfig.maxFailedAttempts && 
+        (!this.reconnecting || this.failedPings % this.pingConfig.maxFailedAttemptsToRetryReconnect == 0)) {
+          if(!this.pingConfig.reconnectIfFailed() ) {
+            this.#emitPingResult(PING_RECONNECT_DRY_RUN, undefined, 0, this.failedPings)
+            callback()
+          } else {
+            this.reconnecting = true
+            this.#retryStrategy(() => {
+              this.redis.disconnect(true);
+              this.#emitPingResult(PING_RECONNECT, undefined, 0, this.failedPings)
+              callback()
+            })
+          }
+    } else {
+      callback()
+    }
   }
 
   #emitPingResult(status, err, duration, failedPings) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -54,11 +54,12 @@ class LimitDBRedis extends EventEmitter {
       redisOptions
     };
 
-    const pingConfig = {
+    this.pingConfig = {
       enabled: config.ping?.enabled || false,
       interval: config.ping?.interval || 1000,
       maxFailedAttempts: config.ping?.maxFailedAttempts || 5,
-      reconnectIfFailed: config.ping?.reconnectIfFailed || false
+      reconnectIfFailed: config.ping?.reconnectIfFailed || false,
+      maxFailedAttemptsToRetryReconnect: 10
     }
 
     this.redis = null;
@@ -66,7 +67,7 @@ class LimitDBRedis extends EventEmitter {
       this.redis = new Redis.Cluster(config.nodes, clusterOptions);
     } else {
       this.redis = new Redis(config.uri, redisOptions);
-      this.setupPing(pingConfig);
+      this.#setupPing();
     }
 
     this.redis.defineCommand('take', {
@@ -92,41 +93,28 @@ class LimitDBRedis extends EventEmitter {
     });
   }
 
-  setupPing(pingConfig) {
-    if (!pingConfig || !pingConfig.enabled) {
+  #setupPing() {
+    if (!this.pingConfig?.enabled) {
       return;
     }
 
     this.failedPings = 0;
     this.once('ready', () => {
-      this.startPing(pingConfig);
+      this.#startPing();
     })
   }
 
-  startPing(config) {
+  #startPing() {
     this.keepPingRunning = true;
     const doPing = () => {
-      this.redis.ping((err, duration, payload) => {
-        if(!err) {
-          this.reconnecting = false
-          this.failedPings = 0;
-          this.emit('ping - success');
-        } else {
-          this.failedPings++;
-          
-          if (this.failedPings >= config.maxFailedAttempts) {
-            if (config.reconnectIfFailed && !this.reconnecting) {
-              this.reconnecting = true
-              this.failedPings = 0;
-              this.redis.disconnect(true);
-              this.emit('ping - reconnect attempted', err);
-            } else {
-              this.emit('ping - fail', err);
-            }
-          }
-        }
+      let hrstart = process.hrtime();
+      this.redis.ping((err, payload) => {
+        let hrend = process.hrtime(hrstart);
+        let duration = hrend[0]*1000 + hrend[1]/1000000
+        err ? this.#pingKO(err, duration) : this.#pingOK(duration);
+
         if(this.keepPingRunning) {
-          this.pingIntervalId = setTimeout(doPing, config.interval);
+          this.pingIntervalId = setTimeout(doPing, this.pingConfig.interval);
         }
       });
     }
@@ -134,7 +122,25 @@ class LimitDBRedis extends EventEmitter {
     doPing();
   }
 
-  stopPing() {
+  #pingOK(duration) {
+    this.reconnecting = false
+    this.failedPings = 0;
+    this.emit('ping - success', duration);
+  }
+
+  #pingKO(err, duration) {
+    this.failedPings++;
+    this.emit('ping - error', err, duration, this.failedPings);
+    
+    if (this.failedPings >= this.pingConfig.maxFailedAttempts && this.pingConfig.reconnectIfFailed && 
+        (!this.reconnecting || this.failedPings % this.pingConfig.maxFailedAttemptsToRetryReconnect == 0)) {
+      this.reconnecting = true
+      this.redis.disconnect(true);
+      this.emit('ping - reconnect attempted', this.failedPings);
+    }
+  }
+
+  #stopPing() {
     this.keepPingRunning = false
     if (this.pingIntervalId) {
       clearTimeout(this.pingIntervalId);
@@ -142,7 +148,7 @@ class LimitDBRedis extends EventEmitter {
   }
 
   close(callback) {
-    this.stopPing();
+    this.#stopPing();
     this.redis.quit(callback);
   }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -54,11 +54,20 @@ class LimitDBRedis extends EventEmitter {
       redisOptions
     };
 
+    const pingConfig = {
+      enabled: config.ping?.enabled || false,
+      interval: config.ping?.interval || 1000,
+      maxFailedAttempts: config.ping?.maxFailedAttempts || 5,
+      reconnectIfFailed: config.ping?.reconnectIfFailed || false
+  
+    }
+
     this.redis = null;
     if (config.nodes) {
       this.redis = new Redis.Cluster(config.nodes, clusterOptions);
     } else {
       this.redis = new Redis(config.uri, redisOptions);
+      this.setupPing(pingConfig);
     }
 
     this.redis.defineCommand('take', {
@@ -82,6 +91,34 @@ class LimitDBRedis extends EventEmitter {
     this.redis.on('node error', (err, node) => {
       this.emit('node error', err, node);
     });
+  }
+
+  setupPing(pingConfig) {
+    if (!pingConfig || !pingConfig.enabled) {
+      return;
+    }
+
+    this.failedPings = 0;
+    this.ping(pingConfig)
+  }
+
+  ping(pingConfig) {
+    this.redis.ping((err, duration, payload) => {
+      if(err) {
+        this.failedPings = 0;
+        this.emit('ping - success');
+      } else {
+        this.failedPings++;
+        if (pingConfig.reconnectIfFailed && this.failedPings >= pingConfig.maxFailedAttempts) {
+          this.redis.disconnect(true)
+          this.emit('ping - reconnect attempted', err)  
+        } else {
+          this.emit('ping - fail', err)
+        }
+      }
+
+      setTimeout(ping(pingConfig), pingConfig.interval)
+    })
   }
 
   close(callback) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -109,14 +109,14 @@ class LimitDBRedis extends EventEmitter {
         return;
       }
       let hrstart = process.hrtime();
-      this.redis.ping((err, payload) => {
+      this.redis.ping((err) => {
         let hrend = process.hrtime(hrstart);
         let duration = hrend[0]*1000 + hrend[1]/1000000;
-        err ? this.#pingKO(err, duration) : this.#pingOK(duration);
-
-        if(this.keepPingRunning) {
-          this.pingIntervalId = setTimeout(doPing, this.pingConfig.interval);
-        }
+        (err ? this.#pingKO(err, duration) : this.#pingOK(duration)).then(() => {
+          if(this.keepPingRunning) {
+            this.pingIntervalId = setTimeout(doPing, this.pingConfig.interval);
+          }
+        });
       });
     }
 
@@ -124,21 +124,38 @@ class LimitDBRedis extends EventEmitter {
   }
 
   #pingOK(duration) {
-    this.reconnecting = false
-    this.failedPings = 0;
-    this.emit('ping - success', duration);
+    return new Promise((res) => {
+      this.reconnecting = false
+      this.failedPings = 0;
+      this.emit('ping - success', duration);
+      res();
+    })
   }
 
   #pingKO(err, duration) {
-    this.failedPings++;
-    this.emit('ping - error', err, duration, this.failedPings);
-    
-    if (this.failedPings >= this.pingConfig.maxFailedAttempts && this.pingConfig.reconnectIfFailed && 
-        (!this.reconnecting || this.failedPings % this.pingConfig.maxFailedAttemptsToRetryReconnect == 0)) {
-      this.reconnecting = true
-      this.redis.disconnect(true);
-      this.emit('ping - reconnect attempted', this.failedPings);
-    }
+    return new Promise((res) => {
+      this.failedPings++;
+      this.emit('ping - error', err, duration, this.failedPings);
+
+      if (this.failedPings >= this.pingConfig.maxFailedAttempts && this.pingConfig.reconnectIfFailed && 
+          (!this.reconnecting || this.failedPings % this.pingConfig.maxFailedAttemptsToRetryReconnect == 0)) {
+        this.reconnecting = true
+        this.#retryStrategy(() => {
+          this.redis.disconnect(true);
+          this.emit('ping - reconnect attempted', this.failedPings);
+          res()
+        })
+      } else {
+        res()
+      }
+    })
+  }
+
+  #retryStrategy(callback) {
+    //jitter between 0% and 10% of the total wait time needed to reconnect
+    //i.e. if interval = 100 and maxFailedAttempts = 3 => it'll randomly jitter between 0 and 30 ms
+    const deviation = utils.randomBetween(0, 0.1) * this.pingConfig.interval * this.pingConfig.maxFailedAttempts
+    setTimeout(callback, deviation)
   }
 
   #stopPing() {

--- a/lib/db.js
+++ b/lib/db.js
@@ -65,7 +65,7 @@ class LimitDBRedis extends EventEmitter {
 
     this.pingConfig = {
       enabled: config.ping ? true : false,
-      interval: config.ping?.interval || 1000,
+      interval: config.ping?.interval || 3000,
       maxFailedAttempts: config.ping?.maxFailedAttempts || 5,
       reconnectIfFailed: utils.functionOrFalse(config.ping?.reconnectIfFailed) || (() => false),
       maxFailedAttemptsToRetryReconnect: config.ping?.maxFailedAttemptsToRetryReconnect || 10

--- a/lib/db.js
+++ b/lib/db.js
@@ -107,7 +107,7 @@ class LimitDBRedis extends EventEmitter {
       return;
     }
     this.failedPings = 0;
-    this.redis.on('ready', () => this.#startPing())  
+    this.redis.on('ready', () => this.#startPing())
   }
 
   #startPing() {
@@ -129,7 +129,7 @@ class LimitDBRedis extends EventEmitter {
     const triggerLoop = (pingTaskId) => 
       this.pingTimeoutId = setTimeout(() => doPing(pingTaskId), this.pingConfig.interval)
 
-    doPing(this.pingTaskId=crypto.randomUUID());
+    doPing(this.pingTaskId);
   }
 
   #pingOK(callback, duration) {
@@ -178,6 +178,7 @@ class LimitDBRedis extends EventEmitter {
     if (this.pingTimeoutId) {
       clearTimeout(this.pingTimeoutId);
     }
+    this.pingTaskId = crypto.randomUUID();
   }
 
   close(callback) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -105,12 +105,14 @@ class LimitDBRedis extends EventEmitter {
 
   #setupPing() {
     this.failedPings = 0;
-    this.once('ready', () => {
-      this.#startPing();
-    })
+    this.redis.on('ready', () => this.#startPing())  
   }
 
   #startPing() {
+    if (this.keepPingRunning) {
+      this.#stopPing()
+    }
+
     this.keepPingRunning = true;
     const doPing = () => {
       if (!this.pingConfig?.enabled()) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -64,12 +64,11 @@ class LimitDBRedis extends EventEmitter {
     };
 
     this.pingConfig = {
-      enabled: utils.functionOrFalse(config.ping?.enabled) || (() => false),
+      enabled: config.ping ? true : false,
       interval: config.ping?.interval || 1000,
       maxFailedAttempts: config.ping?.maxFailedAttempts || 5,
       reconnectIfFailed: utils.functionOrFalse(config.ping?.reconnectIfFailed) || (() => false),
-      maxFailedAttemptsToRetryReconnect: config.ping?.maxFailedAttemptsToRetryReconnect || 10,
-      msBetweenEnabledChecks: config.ping?.msBetweenEnabledChecks || 1000
+      maxFailedAttemptsToRetryReconnect: config.ping?.maxFailedAttemptsToRetryReconnect || 10
     }
 
     this.redis = null;
@@ -104,6 +103,9 @@ class LimitDBRedis extends EventEmitter {
   }
 
   #setupPing() {
+    if (!this.pingConfig.enabled) {
+      return;
+    }
     this.failedPings = 0;
     this.redis.on('ready', () => this.#startPing())  
   }
@@ -115,10 +117,7 @@ class LimitDBRedis extends EventEmitter {
       if (pingTaskId !== this.pingTaskId) {
         return;
       }
-      if (!this.pingConfig?.enabled()) {
-        setTimeout(doPing, this.pingConfig.msBetweenEnabledChecks);
-        return;
-      }
+      
       let start = Date.now();
       this.redis.ping((err) => {
         let duration = Date.now()-start;

--- a/lib/db.js
+++ b/lib/db.js
@@ -10,7 +10,14 @@ const { validateParams } = require('./validation');
 const TAKE_LUA = fs.readFileSync(`${__dirname}/take.lua`, 'utf8');
 const PUT_LUA = fs.readFileSync(`${__dirname}/put.lua`, 'utf8');
 
+const PING_SUCCESS = "successful"
+const PING_ERROR = "error"
+const PING_RECONNECT = "reconnect"
+
 class LimitDBRedis extends EventEmitter {
+  static get PING_SUCCESS () { return PING_SUCCESS };
+  static get PING_ERROR () { return PING_ERROR };
+  static get PING_RECONNECT () { return PING_RECONNECT };
 
   /**
    * Creates an instance of LimitDB client for Redis.
@@ -127,7 +134,7 @@ class LimitDBRedis extends EventEmitter {
     return new Promise((res) => {
       this.reconnecting = false
       this.failedPings = 0;
-      this.emit('ping - success', duration);
+      this.#emitPingResult(PING_SUCCESS, undefined, duration, 0)
       res();
     })
   }
@@ -135,20 +142,30 @@ class LimitDBRedis extends EventEmitter {
   #pingKO(err, duration) {
     return new Promise((res) => {
       this.failedPings++;
-      this.emit('ping - error', err, duration, this.failedPings);
+      this.#emitPingResult(PING_ERROR, err, duration, this.failedPings)
 
       if (this.failedPings >= this.pingConfig.maxFailedAttempts && this.pingConfig.reconnectIfFailed && 
           (!this.reconnecting || this.failedPings % this.pingConfig.maxFailedAttemptsToRetryReconnect == 0)) {
         this.reconnecting = true
         this.#retryStrategy(() => {
           this.redis.disconnect(true);
-          this.emit('ping - reconnect attempted', this.failedPings);
+          this.#emitPingResult(PING_RECONNECT, undefined, 0, this.failedPings)
           res()
         })
       } else {
         res()
       }
     })
+  }
+
+  #emitPingResult(status, err, duration, failedPings) {
+    const result = {
+      status: status,
+      duration: duration,
+      error: err,
+      failedPings: failedPings
+    };
+    this.emit('ping', result);
   }
 
   #retryStrategy(callback) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -59,7 +59,6 @@ class LimitDBRedis extends EventEmitter {
       interval: config.ping?.interval || 1000,
       maxFailedAttempts: config.ping?.maxFailedAttempts || 5,
       reconnectIfFailed: config.ping?.reconnectIfFailed || false
-  
     }
 
     this.redis = null;
@@ -99,29 +98,51 @@ class LimitDBRedis extends EventEmitter {
     }
 
     this.failedPings = 0;
-    this.ping(pingConfig)
-  }
-
-  ping(pingConfig) {
-    this.redis.ping((err, duration, payload) => {
-      if(err) {
-        this.failedPings = 0;
-        this.emit('ping - success');
-      } else {
-        this.failedPings++;
-        if (pingConfig.reconnectIfFailed && this.failedPings >= pingConfig.maxFailedAttempts) {
-          this.redis.disconnect(true)
-          this.emit('ping - reconnect attempted', err)  
-        } else {
-          this.emit('ping - fail', err)
-        }
-      }
-
-      setTimeout(ping(pingConfig), pingConfig.interval)
+    this.once('ready', () => {
+      this.startPing(pingConfig);
     })
   }
 
+  startPing(config) {
+    this.keepPingRunning = true;
+    const doPing = () => {
+      this.redis.ping((err, duration, payload) => {
+        if(!err) {
+          this.reconnecting = false
+          this.failedPings = 0;
+          this.emit('ping - success');
+        } else {
+          this.failedPings++;
+          
+          if (this.failedPings >= config.maxFailedAttempts) {
+            if (config.reconnectIfFailed && !this.reconnecting) {
+              this.reconnecting = true
+              this.failedPings = 0;
+              this.redis.disconnect(true);
+              this.emit('ping - reconnect attempted', err);
+            } else {
+              this.emit('ping - fail', err);
+            }
+          }
+        }
+        if(this.keepPingRunning) {
+          this.pingIntervalId = setTimeout(doPing, config.interval);
+        }
+      });
+    }
+
+    doPing();
+  }
+
+  stopPing() {
+    this.keepPingRunning = false
+    if (this.pingIntervalId) {
+      clearTimeout(this.pingIntervalId);
+    }
+  }
+
   close(callback) {
+    this.stopPing();
     this.redis.quit(callback);
   }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -6,20 +6,31 @@ const utils = require('./utils');
 const Redis = require('ioredis');
 const EventEmitter = require('events').EventEmitter;
 const { validateParams } = require('./validation');
+const DBPing = require("./db_ping");
 
-const TAKE_LUA = fs.readFileSync(`${__dirname}/take.lua`, 'utf8');
-const PUT_LUA = fs.readFileSync(`${__dirname}/put.lua`, 'utf8');
+const TAKE_LUA = fs.readFileSync(`${__dirname}/take.lua`, "utf8");
+const PUT_LUA = fs.readFileSync(`${__dirname}/put.lua`, "utf8");
 
-const PING_SUCCESS = "successful"
-const PING_ERROR = "error"
-const PING_RECONNECT = "reconnect"
-const PING_RECONNECT_DRY_RUN = "reconnect-dry-run"
+const PING_SUCCESS = "successful";
+const PING_ERROR = "error";
+const PING_RECONNECT = "reconnect";
+const PING_RECONNECT_DRY_RUN = "reconnect-dry-run";
+
+const DEFAULT_COMMAND_TIMEOUT = 125; // Milliseconds
 
 class LimitDBRedis extends EventEmitter {
-  static get PING_SUCCESS () { return PING_SUCCESS };
-  static get PING_ERROR () { return PING_ERROR };
-  static get PING_RECONNECT () { return PING_RECONNECT };
-  static get PING_RECONNECT_DRY_RUN () { return PING_RECONNECT_DRY_RUN };
+  static get PING_SUCCESS() {
+    return PING_SUCCESS;
+  }
+  static get PING_ERROR() {
+    return PING_ERROR;
+  }
+  static get PING_RECONNECT() {
+    return PING_RECONNECT;
+  }
+  static get PING_RECONNECT_DRY_RUN() {
+    return PING_RECONNECT_DRY_RUN;
+  }
 
   /**
    * Creates an instance of LimitDB client for Redis.
@@ -45,6 +56,7 @@ class LimitDBRedis extends EventEmitter {
       enableOfflineQueue: false,
       keyPrefix: config.prefix,
       password: config.password,
+      commandTimeout: config.commandTimeout || DEFAULT_COMMAND_TIMEOUT,
       tls: config.tls,
       reconnectOnError: (err) => {
         // will force a reconnect when error starts with `READONLY`
@@ -63,20 +75,12 @@ class LimitDBRedis extends EventEmitter {
       redisOptions
     };
 
-    this.pingConfig = {
-      enabled: config.ping ? true : false,
-      interval: config.ping?.interval || 3000,
-      maxFailedAttempts: config.ping?.maxFailedAttempts || 5,
-      reconnectIfFailed: utils.functionOrFalse(config.ping?.reconnectIfFailed) || (() => false),
-      maxFailedAttemptsToRetryReconnect: config.ping?.maxFailedAttemptsToRetryReconnect || 10
-    }
-
     this.redis = null;
     if (config.nodes) {
       this.redis = new Redis.Cluster(config.nodes, clusterOptions);
     } else {
       this.redis = new Redis(config.uri, redisOptions);
-      this.#setupPing();
+      this.#setupPing(config);
     }
 
     this.redis.defineCommand('take', {
@@ -102,88 +106,25 @@ class LimitDBRedis extends EventEmitter {
     });
   }
 
-  #setupPing() {
-    if (!this.pingConfig.enabled) {
-      return;
-    }
-    this.failedPings = 0;
-    this.redis.on('ready', () => this.#startPing())
+  #setupPing(config) {
+    this.redis.on("ready", () => this.#startPing(config));
+    this.redis.on("close", () => this.#stopPing());
   }
 
-  #startPing() {
+  #startPing(config) {
     this.#stopPing();
-    
-    const doPing = (pingTaskId) => {
-      if (pingTaskId !== this.pingTaskId) {
-        return;
-      }
-      
-      let start = Date.now();
-      this.redis.ping((err) => {
-        let duration = Date.now()-start;
-        let callback = () => triggerLoop(pingTaskId);
-        err ? this.#pingKO(callback, err, duration) : this.#pingOK(callback, duration);
-      });
-    }
-
-    const triggerLoop = (pingTaskId) => 
-      this.pingTimeoutId = setTimeout(() => doPing(pingTaskId), this.pingConfig.interval)
-
-    doPing(this.pingTaskId);
-  }
-
-  #pingOK(callback, duration) {
-    this.reconnecting = false
-    this.failedPings = 0;
-    this.#emitPingResult(PING_SUCCESS, undefined, duration, 0)
-    callback();
-  }
-
-  #pingKO(callback, err, duration) {
-    this.failedPings++;
-    this.#emitPingResult(PING_ERROR, err, duration, this.failedPings)
-
-    if (this.failedPings < this.pingConfig.maxFailedAttempts) {
-      return callback();
-    }
-
-    if(!this.pingConfig.reconnectIfFailed() ) {
-      return this.#emitPingResult(PING_RECONNECT_DRY_RUN, undefined, 0, this.failedPings)
-    }
-
-    this.#retryStrategy(() => {
-      this.#emitPingResult(PING_RECONNECT, undefined, 0, this.failedPings)
-      this.redis.disconnect(true);
-    })
-  }
-
-  #emitPingResult(status, err, duration, failedPings) {
-    const result = {
-      status: status,
-      duration: duration,
-      error: err,
-      failedPings: failedPings
-    };
-    this.emit('ping', result);
-  }
-
-  #retryStrategy(callback) {
-    //jitter between 0% and 10% of the total wait time needed to reconnect
-    //i.e. if interval = 100 and maxFailedAttempts = 3 => it'll randomly jitter between 0 and 30 ms
-    const deviation = utils.randomBetween(0, 0.1) * this.pingConfig.interval * this.pingConfig.maxFailedAttempts
-    setTimeout(callback, deviation)
+    this.ping = new DBPing(config.ping, this.redis);
+    this.ping.on("ping", (data) => this.emit("ping", data));
   }
 
   #stopPing() {
-    if (this.pingTimeoutId) {
-      clearTimeout(this.pingTimeoutId);
-    }
-    this.pingTaskId = crypto.randomUUID();
+    this.ping?.stop();
+    this.ping?.removeAllListeners();
   }
 
   close(callback) {
     this.#stopPing();
-    this.redis.removeAllListeners()
+    this.redis.removeAllListeners();
     this.redis.quit(callback);
   }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -55,11 +55,12 @@ class LimitDBRedis extends EventEmitter {
     };
 
     this.pingConfig = {
-      enabled: config.ping?.enabled || false,
+      enabled: utils.functionOrFalse(config.ping?.enabled) || (() => false),
       interval: config.ping?.interval || 1000,
       maxFailedAttempts: config.ping?.maxFailedAttempts || 5,
       reconnectIfFailed: config.ping?.reconnectIfFailed || false,
-      maxFailedAttemptsToRetryReconnect: config.ping?.maxFailedAttemptsToRetryReconnect || 10
+      maxFailedAttemptsToRetryReconnect: config.ping?.maxFailedAttemptsToRetryReconnect || 10,
+      msBetweenEnabledChecks: config.ping?.msBetweenEnabledChecks || 1000
     }
 
     this.redis = null;
@@ -94,10 +95,6 @@ class LimitDBRedis extends EventEmitter {
   }
 
   #setupPing() {
-    if (!this.pingConfig?.enabled) {
-      return;
-    }
-
     this.failedPings = 0;
     this.once('ready', () => {
       this.#startPing();
@@ -107,10 +104,14 @@ class LimitDBRedis extends EventEmitter {
   #startPing() {
     this.keepPingRunning = true;
     const doPing = () => {
+      if (!this.pingConfig?.enabled()) {
+        setTimeout(doPing, this.pingConfig.msBetweenEnabledChecks);
+        return;
+      }
       let hrstart = process.hrtime();
       this.redis.ping((err, payload) => {
         let hrend = process.hrtime(hrstart);
-        let duration = hrend[0]*1000 + hrend[1]/1000000
+        let duration = hrend[0]*1000 + hrend[1]/1000000;
         err ? this.#pingKO(err, duration) : this.#pingOK(duration);
 
         if(this.keepPingRunning) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -109,12 +109,12 @@ class LimitDBRedis extends EventEmitter {
   }
 
   #startPing() {
-    if (this.keepPingRunning) {
-      this.#stopPing()
-    }
-
-    this.keepPingRunning = true;
-    const doPing = () => {
+    this.#stopPing();
+    
+    const doPing = (pingTaskId) => {
+      if (pingTaskId !== this.pingTaskId) {
+        return;
+      }
       if (!this.pingConfig?.enabled()) {
         setTimeout(doPing, this.pingConfig.msBetweenEnabledChecks);
         return;
@@ -122,17 +122,15 @@ class LimitDBRedis extends EventEmitter {
       let start = Date.now();
       this.redis.ping((err) => {
         let duration = Date.now()-start;
-        err ? this.#pingKO(triggerLoop, err, duration) : this.#pingOK(triggerLoop, duration)
+        let callback = () => triggerLoop(pingTaskId);
+        err ? this.#pingKO(callback, err, duration) : this.#pingOK(callback, duration);
       });
     }
 
-    const triggerLoop = () => {
-      if(this.keepPingRunning) {
-        this.pingIntervalId = setTimeout(doPing, this.pingConfig.interval);
-      }
-    }
+    const triggerLoop = (pingTaskId) => 
+      this.pingTimeoutId = setTimeout(() => doPing(pingTaskId), this.pingConfig.interval)
 
-    doPing();
+    doPing(this.pingTaskId=crypto.randomUUID());
   }
 
   #pingOK(callback, duration) {
@@ -146,22 +144,18 @@ class LimitDBRedis extends EventEmitter {
     this.failedPings++;
     this.#emitPingResult(PING_ERROR, err, duration, this.failedPings)
 
-    if (this.failedPings >= this.pingConfig.maxFailedAttempts && 
-        (!this.reconnecting || this.failedPings % this.pingConfig.maxFailedAttemptsToRetryReconnect == 0)) {
-          if(!this.pingConfig.reconnectIfFailed() ) {
-            this.#emitPingResult(PING_RECONNECT_DRY_RUN, undefined, 0, this.failedPings)
-            callback()
-          } else {
-            this.reconnecting = true
-            this.#retryStrategy(() => {
-              this.redis.disconnect(true);
-              this.#emitPingResult(PING_RECONNECT, undefined, 0, this.failedPings)
-              callback()
-            })
-          }
-    } else {
-      callback()
+    if (this.failedPings < this.pingConfig.maxFailedAttempts) {
+      return callback();
     }
+
+    if(!this.pingConfig.reconnectIfFailed() ) {
+      return this.#emitPingResult(PING_RECONNECT_DRY_RUN, undefined, 0, this.failedPings)
+    }
+
+    this.#retryStrategy(() => {
+      this.#emitPingResult(PING_RECONNECT, undefined, 0, this.failedPings)
+      this.redis.disconnect(true);
+    })
   }
 
   #emitPingResult(status, err, duration, failedPings) {
@@ -182,14 +176,14 @@ class LimitDBRedis extends EventEmitter {
   }
 
   #stopPing() {
-    this.keepPingRunning = false
-    if (this.pingIntervalId) {
-      clearTimeout(this.pingIntervalId);
+    if (this.pingTimeoutId) {
+      clearTimeout(this.pingTimeoutId);
     }
   }
 
   close(callback) {
     this.#stopPing();
+    this.redis.removeAllListeners()
     this.redis.quit(callback);
   }
 

--- a/lib/db_ping.js
+++ b/lib/db_ping.js
@@ -1,0 +1,104 @@
+const EventEmitter = require("events").EventEmitter;
+const utils = require("./utils");
+
+const PING_SUCCESS = "successful";
+const PING_ERROR = "error";
+const PING_RECONNECT = "reconnect";
+const PING_RECONNECT_DRY_RUN = "reconnect-dry-run";
+
+const DEFAULT_PING_INTERVAL = 3000; // Milliseconds
+
+class DBPing extends EventEmitter {
+  constructor(config, redis) {
+    super();
+
+    this.redis = redis;
+    this.config = {
+      enabled: config ? true : false,
+      interval: config?.interval || DEFAULT_PING_INTERVAL,
+      maxFailedAttempts: config?.maxFailedAttempts || 5,
+      reconnectIfFailed:
+        utils.functionOrFalse(config?.reconnectIfFailed) || (() => false),
+    };
+
+    this.failedPings = 0;
+
+    this.#start();
+  }
+
+  #start() {
+    const doPing = () => {
+      if (!this.config.enabled) {
+        return;
+      }
+
+      let start = Date.now();
+      this.redis.ping((err) => {
+        let duration = Date.now() - start;
+        err
+          ? this.#pingKO(triggerLoop, err, duration)
+          : this.#pingOK(triggerLoop, duration);
+      });
+    };
+
+    const triggerLoop = () => setTimeout(doPing, this.config.interval);
+
+    doPing();
+  }
+
+  stop() {
+    this.enabled = false;
+  }
+
+  #pingOK(callback, duration) {
+    this.reconnecting = false;
+    this.failedPings = 0;
+    this.#emitPingResult(PING_SUCCESS, undefined, duration, 0);
+    callback();
+  }
+
+  #pingKO(callback, err, duration) {
+    this.failedPings++;
+    this.#emitPingResult(PING_ERROR, err, duration, this.failedPings);
+
+    if (this.failedPings < this.config.maxFailedAttempts) {
+      return callback();
+    }
+
+    if (!this.config.reconnectIfFailed()) {
+      return this.#emitPingResult(
+        PING_RECONNECT_DRY_RUN,
+        undefined,
+        0,
+        this.failedPings
+      );
+    }
+
+    this.#retryStrategy(() => {
+      this.#emitPingResult(PING_RECONNECT, undefined, 0, this.failedPings);
+      this.redis.disconnect(true);
+    });
+  }
+
+  #emitPingResult(status, err, duration, failedPings) {
+    const result = {
+      status: status,
+      duration: duration,
+      error: err,
+      failedPings: failedPings,
+    };
+    this.emit("ping", result);
+  }
+
+  #retryStrategy(callback) {
+    //jitter between 0% and 10% of the total wait time needed to reconnect
+    //i.e. if interval = 100 and maxFailedAttempts = 3 => it'll randomly jitter between 0 and 30 ms
+    const deviation =
+      utils.randomBetween(0, 0.1) *
+      this.config.interval *
+      this.config.maxFailedAttempts;
+    setTimeout(callback, deviation);
+  }
+}
+
+module.exports = DBPing;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -93,11 +93,21 @@ function functionOrFalse(fun) {
     : false
 }
 
+function randomBetween(min, max) {
+  if (min > max) {
+    let tmp = max;
+    max = min;
+    min = tmp;
+  }
+  return Math.random() * (max-min) + min;
+}
+
 module.exports = {
   buildBuckets,
   buildBucket,
   INTERVAL_SHORTCUTS,
   normalizeTemporals,
   normalizeType,
-  functionOrFalse
+  functionOrFalse,
+  randomBetween
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,10 +87,17 @@ function buildBucket(bucket) {
   return normalizeType(bucket);
 }
 
+function functionOrFalse(fun) {
+  return !!(fun && fun.constructor && fun.call && fun.apply)
+    ? fun
+    : false
+}
+
 module.exports = {
   buildBuckets,
   buildBucket,
   INTERVAL_SHORTCUTS,
   normalizeTemporals,
-  normalizeType
+  normalizeType,
+  functionOrFalse
 };

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "lodash": "^4.17.15",
     "lru-cache": "^4.1.5",
     "ms": "^2.1.2",
-    "retry": "^0.12.0",
-    "toxiproxy-node-client": "^2.0.6"
+    "retry": "^0.12.0"
   },
   "devDependencies": {
     "chai": "^4.1.2",
     "eslint": "^6.1.0",
     "mocha": "^5.2.0",
-    "nyc": "^14.1.1"
+    "nyc": "^14.1.1",
+    "toxiproxy-node-client": "^2.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lodash": "^4.17.15",
     "lru-cache": "^4.1.5",
     "ms": "^2.1.2",
-    "retry": "^0.12.0"
+    "retry": "^0.12.0",
+    "toxiproxy-node-client": "^2.0.6"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -1163,7 +1163,6 @@ describe.only('LimitDBRedis Ping', () => {
     let tmpDB = new LimitDB(config)
 
     tmpDB.on(('error'), (err) => {
-      console.log("ERROR")
       //As we actively close the connection, there might be network-related errors while attempting to reconnect
       if (err?.message.indexOf('enableOfflineQueue') > 0) {
         err = undefined;

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -995,7 +995,8 @@ describe('LimitDBRedis', () => {
       enabled: true,
       interval: 10,
       maxFailedAttempts: 3,
-      reconnectIfFailed: true
+      reconnectIfFailed: true,
+      maxFailedAttemptsToRetryReconnect: 10
     }
   
     let redisProxy;

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -1108,7 +1108,7 @@ describe('LimitDBRedis', () => {
 
       setTimeout(() => enabled = true, 200);
 
-      db.on(('ping - success'), (duration) => {
+      db.once(('ping - success'), (duration) => {
         pingReceived = true;
         if (enabled) {
           done();


### PR DESCRIPTION
Added an app-level ping to determine if the connection with Redis is alive or not. This only works in single mode, as we're already covered for Cluster mode.

It will emit the following events:

- **ping - success**: Every time a ping is successfully answered by Redis.
- **ping - fail**: Every time a ping fails to be answered by Redis.
- **ping - reconnect attemped**: Every time the library attempts to reconnect with Redis.

This new feature is **DISABLED** by default. In order to enable it, the users will need to send a new **ping** attribute on the LimitDB constructor with the following format:
```javascript
ping = {
      interval: 3000, //the ping interval expressed in ms. Defaults to 3000.
      maxFailedAttempts: 5, //the max allowed failed attempts before trying to reconnect. Defaults to 5.
      reconnectIfFailed: true //whether it will try to reconnect or not after failing ***maxFailedAttempts***. Defaults to true.
}
```
https://auth0team.atlassian.net/browse/PSERV-1629

## On how to reproduce the issue in MacOS
- edit /etc/pf.conf
- add 
  ```block drop in on lo0 proto tcp from any to any port = 22222```
- reload rules
  ```sudo pfctl -f /etc/pf.conf```

### Findings after reproducing the issue
- I was able to reproduce the issue. ioredis doesn't realize the connection is down
- There is no automatic reconnection attempt from ioredis when the TCP flow stops abruptly
- When the TCP flow is gently closed, ioredis attempts to automatically reconnect
- When the issue was reproduced, the ping command was enqueued and never timed out. 

## Introducing a Timeout
- There is a ```commandTimeout``` attribute in the [Redis Options](https://github.com/redis/ioredis/blob/v5.0.6/lib/redis/RedisOptions.ts) that is set to ```undefined``` by default. If it's kept as undefined, the command will not be set a timeout, hence will wait forever. Setting this commandTimeout as part of our redisOptions structure, makes the command fail. This is needed so the pings don't get enqueued waiting forever:

### Testing

There are unit tests covering this feature. If you want to manually check this, the best way would be to make use of the library with a dockerized Redis instance which you could stop whenever you want to check if you get the proper events emitted.

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
