### PR TITLE
Cache non-conformant answers and fix reset times

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Buckets:
 - `per_interval` (number): is the amount of tokens that the bucket receive on every interval.
 - `interval` (number): defines the interval in milliseconds.
 - `unlimited` (boolean = false): unlimited requests (skip take).
-- `disable_cache` (boolean = false): prevent cacheing when a bucket is empty until the next drip.
+- `disable_cache` (boolean = false): prevent caching when a bucket is empty until the next drip.
 
 You can also define your rates using `per_second`, `per_minute`, `per_hour`, `per_day`. So `per_second: 1` is equivalent to `per_interval: 1, interval: 1000`.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Buckets:
 - `per_interval` (number): is the amount of tokens that the bucket receive on every interval.
 - `interval` (number): defines the interval in milliseconds.
 - `unlimited` (boolean = false): unlimited requests (skip take).
+- `disable_cache` (boolean = false): prevent cacheing when a bucket is empty until the next drip.
 
 You can also define your rates using `per_second`, `per_minute`, `per_hour`, `per_day`. So `per_second: 1` is equivalent to `per_interval: 1, interval: 1000`.
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,9 +1,9 @@
 const _ = require('lodash');
 const retry = require('retry');
 const cbControl = require('./cb');
-const validation = require('./validation');
 const LimitDBRedis = require('./db');
 const disyuntor = require('disyuntor');
+const validation = require('./validation');
 const EventEmitter = require('events').EventEmitter;
 
 const ValidationError = validation.LimitdRedisValidationError;
@@ -29,7 +29,9 @@ class LimitdRedis extends EventEmitter {
   constructor(params) {
     super();
 
-    this.db = new LimitDBRedis(_.pick(params, ['uri', 'nodes', 'buckets', 'prefix', 'slotsRefreshTimeout', 'slotsRefreshInterval', 'password', 'tls', 'dnsLookup', 'globalTTL']));
+    this.db = new LimitDBRedis(_.pick(params, [
+      'uri', 'nodes', 'buckets', 'prefix', 'slotsRefreshTimeout', 'slotsRefreshInterval',
+      'password', 'tls', 'dnsLookup', 'globalTTL', 'cache']));
 
     this.db.on('error', (err) => {
       this.emit('error', err);

--- a/lib/db.js
+++ b/lib/db.js
@@ -4,8 +4,10 @@ const _ = require('lodash');
 const async = require('async');
 const utils = require('./utils');
 const Redis = require('ioredis');
-const EventEmitter = require('events').EventEmitter;
+const TTLCache = require('@isaacs/ttlcache');
 const { validateParams } = require('./validation');
+const {parseInt} = require("lodash");
+const EventEmitter = require('events').EventEmitter;
 
 const TAKE_LUA = fs.readFileSync(`${__dirname}/take.lua`, 'utf8');
 const PUT_LUA = fs.readFileSync(`${__dirname}/put.lua`, 'utf8');
@@ -82,6 +84,12 @@ class LimitDBRedis extends EventEmitter {
     this.redis.on('node error', (err, node) => {
       this.emit('node error', err, node);
     });
+
+    this.cache = config.cache || new TTLCache({
+      max: 1000,
+      ttl: 1000,
+      checkAgeOnGet: true
+    });
   }
 
   close(callback) {
@@ -129,6 +137,7 @@ class LimitDBRedis extends EventEmitter {
     return type;
   }
 
+  // not super accurate given clock drift across redis and host
   calculateReset(bucketKeyConfig, remaining, now) {
     if (!bucketKeyConfig.per_interval) {
       return 0;
@@ -136,10 +145,13 @@ class LimitDBRedis extends EventEmitter {
 
     now = now || Date.now();
     const missing = bucketKeyConfig.size - remaining;
-    const msToCompletion = Math.ceil(missing * bucketKeyConfig.interval / bucketKeyConfig.per_interval);
+    const msToCompletion = Math.ceil(missing * bucketKeyConfig.drip_interval);
     return Math.ceil((now + msToCompletion) / 1000);
   }
 
+  cacheEnabled(bucket) {
+    return !bucket.disable_cache;
+  }
 
   /**
    * Take N elements from a bucket if available.
@@ -155,6 +167,9 @@ class LimitDBRedis extends EventEmitter {
 
     const bucket = this.buckets[params.type];
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
+
+    const cacheEnabled = this.cacheEnabled(bucketKeyConfig);
+    const key = `${params.type}:${params.key}`;
 
     const count = this._determineCount({
       paramsCount: params.count,
@@ -172,24 +187,46 @@ class LimitDBRedis extends EventEmitter {
       });
     }
 
-    this.redis.take(`${params.type}:${params.key}`,
-      bucketKeyConfig.per_interval / bucketKeyConfig.interval || 0,
+    if (cacheEnabled) {
+      const cached = this.cache.get(key);
+      if (cached) {
+        return callback(null, cached);
+      }
+    }
+
+    this.redis.take(key,
+      bucketKeyConfig.ms_per_interval || 0,
       bucketKeyConfig.size,
       count,
-      Math.floor(bucketKeyConfig.ttl || this.globalTTL),
+      Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
+      bucketKeyConfig.drip_interval || 0,
       (err, results) => {
         if (err) {
           return callback(err);
         }
 
         const remaining = parseInt(results[0], 10);
-        return callback(null, {
-          conformant: parseInt(results[1], 10) ? true : false,
+        const conformant = parseInt(results[1], 10) ? true : false;
+        const currentMS = parseInt(results[2], 10);
+        const reset = parseInt(results[3], 10);
+        const res = {
+          conformant,
           remaining,
-          reset: this.calculateReset(bucketKeyConfig, remaining, parseInt(results[2], 10)),
+          reset: reset / 1000,
           limit: bucketKeyConfig.size,
           delayed: false
-        });
+        };
+
+        if (cacheEnabled && conformant === false) {
+          // cache if bucket is empty and only until almost the moment it should get a new token
+          const msUntilFull = reset - currentMS;
+          const ttl = Math.floor(msUntilFull / bucketKeyConfig.size * 0.99);
+          if (ttl) { // can't cache 0
+            this.cache.set(key, res, { ttl });
+          }
+        }
+
+        return callback(null, res);
       });
   }
 
@@ -261,7 +298,8 @@ class LimitDBRedis extends EventEmitter {
     this.redis.put(key,
       count,
       bucketKeyConfig.size,
-      Math.floor(bucketKeyConfig.ttl || this.globalTTL),
+      Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
+      bucketKeyConfig.drip_interval || 0,
       (err, results) => {
         if (err) {
           return callback(err);
@@ -270,7 +308,7 @@ class LimitDBRedis extends EventEmitter {
         const remaining = parseInt(results[0], 10);
         return callback(null, {
           remaining: remaining,
-          reset: this.calculateReset(bucketKeyConfig, remaining, parseInt(results[1], 10)),
+          reset: parseInt(results[3], 10) / 1000,
           limit: bucketKeyConfig.size
         });
       });

--- a/lib/db.js
+++ b/lib/db.js
@@ -6,7 +6,6 @@ const utils = require('./utils');
 const Redis = require('ioredis');
 const TTLCache = require('@isaacs/ttlcache');
 const { validateParams } = require('./validation');
-const {parseInt} = require("lodash");
 const EventEmitter = require('events').EventEmitter;
 
 const TAKE_LUA = fs.readFileSync(`${__dirname}/take.lua`, 'utf8');
@@ -183,7 +182,8 @@ class LimitDBRedis extends EventEmitter {
         remaining: bucketKeyConfig.size,
         reset: Math.ceil(Date.now() / 1000),
         limit: bucketKeyConfig.size,
-        delayed: false
+        delayed: false,
+        cached: false
       });
     }
 
@@ -214,7 +214,8 @@ class LimitDBRedis extends EventEmitter {
           remaining,
           reset: Math.ceil(reset / 1000),
           limit: bucketKeyConfig.size,
-          delayed: false
+          delayed: false,
+          cached: false
         };
 
         if (cacheEnabled && conformant === false) {
@@ -222,7 +223,7 @@ class LimitDBRedis extends EventEmitter {
           const msUntilFull = reset - currentMS;
           const ttl = Math.floor(msUntilFull / bucketKeyConfig.size * 0.99);
           if (ttl) { // can't cache 0
-            this.cache.set(key, res, { ttl });
+            this.cache.set(key, Object.assign({}, res, {cached: true}), { ttl });
           }
         }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -212,7 +212,7 @@ class LimitDBRedis extends EventEmitter {
         const res = {
           conformant,
           remaining,
-          reset: reset / 1000,
+          reset: Math.ceil(reset / 1000),
           limit: bucketKeyConfig.size,
           delayed: false
         };
@@ -308,7 +308,7 @@ class LimitDBRedis extends EventEmitter {
         const remaining = parseInt(results[0], 10);
         return callback(null, {
           remaining: remaining,
-          reset: parseInt(results[3], 10) / 1000,
+          reset: Math.ceil(parseInt(results[3], 10) / 1000),
           limit: bucketKeyConfig.size
         });
       });

--- a/lib/put.lua
+++ b/lib/put.lua
@@ -1,6 +1,7 @@
 local tokens_to_add        = tonumber(ARGV[1])
 local bucket_size          = tonumber(ARGV[2])
 local ttl                  = tonumber(ARGV[3])
+local drip_interval        = tonumber(ARGV[4])
 
 local current_time = redis.call('TIME')
 local current_timestamp_ms = current_time[1] * 1000 + current_time[2] / 1000
@@ -22,4 +23,9 @@ else
   redis.call('DEL', KEYS[1])
 end
 
-return { new_content, current_timestamp_ms }
+local reset_ms = 0
+if drip_interval > 0 then
+    reset_ms = math.ceil(current_timestamp_ms + (bucket_size - new_content) * drip_interval)
+end
+
+return { new_content, current_timestamp_ms, reset_ms }

--- a/lib/take.lua
+++ b/lib/take.lua
@@ -3,6 +3,7 @@ local bucket_size          = tonumber(ARGV[2])
 local new_content          = tonumber(ARGV[2])
 local tokens_to_take       = tonumber(ARGV[3])
 local ttl                  = tonumber(ARGV[4])
+local drip_interval  = tonumber(ARGV[5])
 
 local current_time = redis.call('TIME')
 local current_timestamp_ms = current_time[1] * 1000 + current_time[2] / 1000
@@ -39,4 +40,9 @@ redis.call('HMSET', KEYS[1],
             'r', new_content)
 redis.call('EXPIRE', KEYS[1], ttl)
 
-return { new_content, enough_tokens, current_timestamp_ms }
+local reset_ms = 0
+if drip_interval > 0 then
+    reset_ms = math.ceil(current_timestamp_ms + (bucket_size - new_content) * drip_interval)
+end
+
+return { new_content, enough_tokens, current_timestamp_ms, reset_ms }

--- a/lib/take.lua
+++ b/lib/take.lua
@@ -3,7 +3,7 @@ local bucket_size          = tonumber(ARGV[2])
 local new_content          = tonumber(ARGV[2])
 local tokens_to_take       = tonumber(ARGV[3])
 local ttl                  = tonumber(ARGV[4])
-local drip_interval  = tonumber(ARGV[5])
+local drip_interval        = tonumber(ARGV[5])
 
 local current_time = redis.call('TIME')
 local current_timestamp_ms = current_time[1] * 1000 + current_time[2] / 1000

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,7 +16,8 @@ function normalizeTemporals(params) {
     'per_interval',
     'interval',
     'size',
-    'unlimited'
+    'unlimited',
+    'disable_cache'
   ]);
 
   INTERVAL_SHORTCUTS.forEach(intervalShortcut => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,6 +31,12 @@ function normalizeTemporals(params) {
 
   if (type.per_interval) {
     type.ttl = ((type.size * type.interval) / type.per_interval) / 1000;
+    type.ms_per_interval = type.per_interval / type.interval;
+    type.drip_interval = type.interval / type.per_interval;
+  }
+
+  if (!type.per_interval) {
+    type.disable_cache = true;
   }
 
   return type;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "Auth0",
   "license": "MIT",
   "dependencies": {
+    "@isaacs/ttlcache": "^1.4.0",
     "async": "^2.6.1",
     "disyuntor": "^3.5.0",
     "ioredis": "^4.28.5",

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -538,6 +538,7 @@ describe('LimitDBRedis', () => {
           assert.ifError(err);
           assert.equal(res.conformant, false);
           assert.equal(res.remaining, 0);
+          assert.equal(res.cached, false);
           assert.equal(db.cache.has('cached:fixed'), false);
           done();
         });
@@ -553,6 +554,7 @@ describe('LimitDBRedis', () => {
           assert.ifError(err);
           assert.equal(res.conformant, false);
           assert.equal(res.remaining, 0);
+          assert.equal(res.cached, false);
           const ttl = db.cache.getRemainingTTL('cached:test');
           assert(ms('30m') > ttl);
           assert(ms('29m') < ttl);
@@ -569,6 +571,7 @@ describe('LimitDBRedis', () => {
           assert.ifError(err);
           assert.equal(res.conformant, false);
           assert.equal(res.remaining, 0);
+          assert.equal(res.cached, false);
           const ttl = db.cache.getRemainingTTL('cached:faster');
           assert(ms('1s') > ttl);
           assert(ms('900ms') < ttl);
@@ -586,8 +589,30 @@ describe('LimitDBRedis', () => {
           assert.ifError(err);
           assert.equal(res.conformant, false);
           assert.equal(res.remaining, 0);
+          assert.equal(res.cached, false);
           assert.equal(db.cache.has('cached:disabled'), false);
           done();
+        });
+      });
+    });
+    it('should indicate the response came from cache', (done) => {
+      db.take({type: 'cached', key: 'test', count: 3}, (err, res) => {
+        assert.ifError(err);
+        assert.equal(res.conformant, true);
+        assert.equal(res.remaining, 0);
+        db.take({type: 'cached', key: 'test'}, (err, res) => {
+          assert.ifError(err);
+          assert.equal(res.conformant, false);
+          assert.equal(res.remaining, 0);
+          assert.equal(res.cached, false);
+
+          db.take({type: 'cached', key: 'test'}, (err, res) => {
+            assert.ifError(err);
+            assert.equal(res.conformant, false);
+            assert.equal(res.remaining, 0);
+            assert.equal(res.cached, true);
+            done();
+          });
         });
       });
     });

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -65,6 +65,11 @@ const buckets = {
       faster: {
         size: 3,
         per_second: 1,
+      },
+      disabled: {
+        size: 5,
+        per_hour: 2,
+        disable_cache: true
       }
     }
   }
@@ -533,11 +538,10 @@ describe('LimitDBRedis', () => {
           assert.ifError(err);
           assert.equal(res.conformant, false);
           assert.equal(res.remaining, 0);
-
           assert.equal(db.cache.has('cached:fixed'), false);
           done();
         });
-      })
+      });
     });
 
     it('should cache buckets intervals until their reset', (done) => {
@@ -554,7 +558,7 @@ describe('LimitDBRedis', () => {
           assert(ms('29m') < ttl);
           done();
         });
-      })
+      });
     });
     it('should cache buckets accurately in small windows', (done) => {
       db.take({type: 'cached', key: 'faster', count: 3}, (err, res) => {
@@ -570,7 +574,22 @@ describe('LimitDBRedis', () => {
           assert(ms('900ms') < ttl);
           done();
         });
-      })
+      });
+    });
+
+    it('should not cache when disable_cache is true', (done) => {
+      db.take({type: 'cached', key: 'disabled', count: 5}, (err, res) => {
+        assert.ifError(err);
+        assert.equal(res.conformant, true);
+        assert.equal(res.remaining, 0);
+        db.take({type: 'cached', key: 'disabled'}, (err, res) => {
+          assert.ifError(err);
+          assert.equal(res.conformant, false);
+          assert.equal(res.remaining, 0);
+          assert.equal(db.cache.has('cached:disabled'), false);
+          done();
+        });
+      });
     });
   });
 


### PR DESCRIPTION
1. Cache non fixed sized buckets when empty up until the next drip.
2. Build reset from redis time instead of local time for correctness in both headers and cache ttl.
3. Minor fixes along with removing duplicate calculations

Naive benchmark code:
```js
  it.only('bench', (done) => {
    const startDisabled = Date.now();
    async.eachSeries(_.range(10000), (_, done) => {
      db.take({type: 'cached', key: 'disabled'}, done);
    }, (err) => {
      assert.ifError(err);
      console.log('Cache Disabled', Date.now() - startDisabled);
      const startEnabled = Date.now();
      async.eachSeries(_.range(10000), (_, done) => {
        db.take({type: 'cached', key: 'bench'}, done);
      }, (err) => {
        assert.ifError(err);
        console.log('Cache Enabled', Date.now() - startEnabled);
        done();
      });
    });
  });
```

```
Cache Disabled 9531
Cache Enabled 29
```

Reference: https://auth0.slack.com/archives/C0253762S14/p1687914229712639