### PR TITLE
feat: relax take count's

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Buckets:
 - `per_interval` (number): is the amount of tokens that the bucket receive on every interval.
 - `interval` (number): defines the interval in milliseconds.
 - `unlimited` (boolean = false): unlimited requests (skip take).
+- `skip_n_calls` (number): take will go to redis every `n` calls instead of going in every take. 
 
 Ping:
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -2,6 +2,7 @@ const ms = require('ms');
 const fs = require('fs');
 const _ = require('lodash');
 const async = require('async');
+const LRU = require('lru-cache');
 const utils = require('./utils');
 const Redis = require('ioredis');
 const { validateParams } = require('./validation');
@@ -51,6 +52,7 @@ class LimitDBRedis extends EventEmitter {
     this.configurateBuckets(config.buckets);
     this.prefix = config.prefix;
     this.globalTTL = (config.globalTTL || ms('7d')) / 1000;
+    this.callCounts = new LRU({ max: 50 });
 
     const redisOptions = {
       // a low commandTimeout value would likely cause sharded clusters to fail `enableReadyCheck` due to it running `CLUSTER INFO`
@@ -199,7 +201,7 @@ class LimitDBRedis extends EventEmitter {
 
     const key = `${params.type}:${params.key}`;
 
-    const count = this._determineCount({
+    let count = this._determineCount({
       paramsCount: params.count,
       defaultCount: 1,
       bucketKeyConfigSize: bucketKeyConfig.size,
@@ -213,6 +215,31 @@ class LimitDBRedis extends EventEmitter {
         limit: bucketKeyConfig.size,
         delayed: false,
       });
+    }
+
+    if (bucketKeyConfig.skip_n_calls > 0) {
+      const prevCall = this.callCounts.get(key);
+
+      if (prevCall) {
+        const shouldGoToRedis = prevCall?.count >= bucketKeyConfig.skip_n_calls
+
+
+        if (!shouldGoToRedis) {
+          prevCall.count ++;
+          return process.nextTick(callback, null, prevCall.res);
+        }
+
+        // if lastCall not exists it's the first time that we go to redis.
+        // so we don't change count; subsequently calls take count should be
+        // proportional to the number of call that we skip.
+        // if count=3, and we go every 5 times, take should 15
+        // This parameter is most likely 1, and doing times is an overkill but better safe than sorry.
+        if (shouldGoToRedis) {
+          count *= bucketKeyConfig.skip_n_calls;
+        }
+      }
+
+
     }
 
     this.redis.take(key,
@@ -237,6 +264,10 @@ class LimitDBRedis extends EventEmitter {
           limit: bucketKeyConfig.size,
           delayed: false,
         };
+
+        if (bucketKeyConfig.skip_n_calls > 0) {
+          this.callCounts.set(key, { res, count: 0 });
+        }
 
         return callback(null, res);
       });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,6 +17,7 @@ function normalizeTemporals(params) {
     'interval',
     'size',
     'unlimited',
+    'skip_n_calls'
   ]);
 
   INTERVAL_SHORTCUTS.forEach(intervalShortcut => {


### PR DESCRIPTION

### Description

This PR makes use of a  local count. Instead of going to Redis every time, with this new configuration will go to Redis every N time, helping to relieve some pressure over Redis when needed.


### References



### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
