### PR TITLE
chore: add explicit callCounts.set to avoid future inconvenience

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -226,6 +226,7 @@ class LimitDBRedis extends EventEmitter {
 
         if (!shouldGoToRedis) {
           prevCall.count ++;
+          this.callCounts.set(key, prevCall);
           return process.nextTick(callback, null, prevCall.res);
         }
 


### PR DESCRIPTION
This has no direct impact on how things work because the cache is returning a reference to the object that is being stored. Modifying that object will cause the object in the cache to go through the modification. This explicit set prevents the reader from thinking that it's missing some how.