### PR TITLE
fix: [PSERV-2110] skip_n_calls take amount accounts for current call

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -236,6 +236,9 @@ class LimitDBRedis extends EventEmitter {
         // This parameter is most likely 1, and doing times is an overkill but better safe than sorry.
         if (shouldGoToRedis) {
           count *= bucketKeyConfig.skip_n_calls;
+
+          // we need to increment to account for the skipped calls + the current call
+          count++
         }
       }
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -235,10 +235,8 @@ class LimitDBRedis extends EventEmitter {
         // if count=3, and we go every 5 times, take should 15
         // This parameter is most likely 1, and doing times is an overkill but better safe than sorry.
         if (shouldGoToRedis) {
-          count *= bucketKeyConfig.skip_n_calls;
-
-          // we need to increment to account for the skipped calls + the current call
-          count++
+          // we need to account for the skipped calls + the current call
+          count *= (bucketKeyConfig.skip_n_calls + 1);
         }
       }
 


### PR DESCRIPTION
### Description

This PR fixes an issue where `skip_n_calls` would inaccurately limit received requests.

<details><summary>Local Test Results</summary>
<p>

Tests generated locally using testing tools added here: https://github.com/auth0/platform-core-services-tools/pull/24/files

The graphs below show the number of conformant requests under the following conditions:
```
- 10 nodes making requests at 330 RPS (3300 total)
- global rate limit configured to 1000 RPS
```

####  Before Fix

![image](https://github.com/auth0/limitd-redis/assets/36539330/1aecec17-5f7a-4098-9cb2-24b6b965826b)

Notice that it is limiting to **1.4k RPS** instead of **1k RPS**

####  After Fix

The graph below shows the number of conformant requests under the following conditions:
```
- 10 nodes making requests at 330 RPS (3300 total)
- global rate limit configured to 1000 RPS
```

![image](https://github.com/limitd/limitdb/assets/36539330/acd1d0dd-3526-412d-9902-d6a475770b1f)

Notice that it is now correctly limiting to **1k RPS**

#### Other Local Test Case Results

| Nodes | Limit Per Second | `skip_n_calls` | Rough Estimate of Allowed RPS |
| --- | --- | --- | --- |
| 10 | 1000 | 0 | 997.6567443255674 |
| 10 | 1000 | 10 | 1014.9835699962139 |
| 10 | 1000 | 20 | 1031.8201798598202 |
| | | | |
| 10 | 2000 | 0 | 2008.1796153717962 |
| 10 | 2000 | 10 | 1975.5858597281813 |
| 10 | 2000 | 20 | 2009.101272813409 |
| | | | |
| 20 | 1000 | 0 | 1004.0967691042822 |
| 20 | 1000 | 10 | 1026.260158211675 |
| 20 | 1000 | 20 | 967.3338773895454 |
| | | | |
| 20 | 2000 | 0 | 2002.9174408932795 |
| 20 | 2000 | 20 | 1986.750242652974 |
| | | | |
| 30 | 1000 | 10 | 951.6324449810605 |
</p>
</details> 


#### Root Cause:

When taking tokens after skipping calls to `redis`, we were taking tokens to account for the skipped calls, but **not** for the current call.

<details>
<summary> This off-by-one error explains why the results were more prominent when `n` is small. </summary>
<p> 

![image](https://github.com/auth0/limitd-redis/assets/36539330/28bd539d-5a77-4749-bce0-e8c4fabdeedd)
</p>
</details>

<details>
<summary>Examples</summary>
<p>

When `skip_n_calls` is 1 we would do the following:

| | Before | After |
| --- | --- | --- |
| | **(bucket = 3)** | **(bucket = 3)** |
| call 1 | take 1 token from `redis` - **(bucket = 2)** | take 1 token from `redis` **(bucket = 2)** |
| call 2 | skip **(bucket = 2)** | skip **(bucket = 2)** |
| call 3 | take `n` tokens from `redis`. n = 1. **(bucket = 1)** | take `n` + 1 tokens from `redis`; one for the previously skipped call, and one for this call. **(bucket = 0)** |

When `skip_n_calls` is 3 we would do the following:

| | Before | After |
| --- | --- | --- |
| | **(bucket = 5)** | **(bucket = 5)** |
| call 1 | take 1 token from `redis` - **(bucket = 4)** | take 1 token from `redis` **(bucket = 4)** |
| call 2 | skip **(bucket = 4)** | skip **(bucket = 4)** |
| call 3 | skip **(bucket = 4)** | skip **(bucket = 4)** |
| call 4 |  skip **(bucket = 4)** | skip **(bucket = 4)** |
| call 5 | take `n` tokens from `redis`. n = 3. **(bucket = 1)** | take `n` + 1 tokens from `redis`; one for the previously skipped call, and one for this call. **(bucket = 0)** |

</p>
</details> 

### References

[Slack Discussion
](https://auth0.slack.com/archives/C05DEDD6V70/p1698950476985339)[Jira](https://auth0team.atlassian.net/browse/PSERV-2110)

### Testing

- [x] Integration testing
- [ ] Dev Environment Load Testing

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
