### PR TITLE
chore: bump version to 7.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd-redis",
-  "version": "7.8.0",
+  "version": "7.8.1",
   "description": "A database client for limits on top of redis",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Bumps version from `7.8.0` to `7.8.1`

### Description

New version includes
- fix for [skip_n_calls](https://github.com/auth0/limitd-redis/pull/50)

Note: Bumping the [patch](https://semver.org/) number here as it is a backwards compatible change.
<details><summary>Semantic Versioning</summary>
<p>

> Given a version number MAJOR.MINOR.PATCH, increment the:
> 
> MAJOR version when you make incompatible API changes
> MINOR version when you add functionality in a backward compatible manner
> PATCH version when you make backward compatible bug fixes
> Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
https://semver.org/
</p>
</details> 

### References

https://github.com/auth0/limitd-redis/pull/50
https://auth0team.atlassian.net/browse/PSERV-2110

### Testing

N/A

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
