### PR TITLE
feat: Elevated Rate Limits core mechanism  (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ERL is a feature that allows you to define a different set of limits that kick i
 The feature aims to provide a way to temporarily allow a higher rate of requests when the bucket is empty, for a limited period of time.
 
 To be able to allow its use within limitd-redis, you need to:
-1. call the `take` method with the parameter `allowERL` set to `true`.
+1. call the `takeElevated` method.
 2. pass the `erlIsActiveKey` parameter with the identifier of the ERL activation for the bucket. This works similarly to the `key` you pass to `limitd.take`, which is the identifier of the bucket; however it's used to track the ERL activation for the bucket instead.
 3. make sure that the bucket definition has ERL configured.
 
@@ -138,6 +138,8 @@ buckets = {
 }
 ```
 
+The overrides in ERL work the same way as for the regular bucket. Both size and per_interval are mandatory when specifying an override. 
+
 ## Breaking changes from `Limitdb`
 
 * Elements will have a default TTL of a week unless specified otherwise.
@@ -156,8 +158,30 @@ limitd.take(type, key, { count, configOverride, erlIsActive, allowERL}, (err, re
 -  `key`: the identifier of the bucket.
 -  `count`: the amount of tokens you need. This is optional and the default is 1.
 -  `configOverride`: caller-provided bucket configuration for this operation
--  `erlIsActiveKey`: (string) the identifier of the ERL activation for the bucket. Only mandatory to pass while operating on buckets that have ERL configured.
--  `allowERL`: (boolean) optional. if set to true, the ERL feature will be allowed to be used.
+
+The result object has:
+-  `conformant` (boolean): true if the requested amount is conformant to the limit.
+-  `remaining` (int): the amount of remaining tokens in the bucket.
+-  `reset` (int / unix timestamp): unix timestamp of the date when the bucket will be full again.
+-  `limit` (int): the size of the bucket.
+
+## TAKEELEVATED
+
+This take operation allows the use of elevated rate limits if it corresponds.
+
+```js
+limitd.takeElevated(type, key, { count, configOverride, erlIsActive }, (err, result) => {
+  console.log(result);
+});
+```
+
+`limitd.takeElevated` takes the following arguments:
+
+-  `type`: the bucket type.
+-  `key`: the identifier of the bucket.
+-  `count`: the amount of tokens you need. This is optional and the default is 1.
+-  `configOverride`: caller-provided bucket configuration for this operation
+-  `erlIsActiveKey`: (string) the identifier of the ERL activation for the bucket.
 
 The result object has:
 -  `conformant` (boolean): true if the requested amount is conformant to the limit.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const limitd = new Limitd({
 });
 ```
 
-Options available:
+### Options available:
 
 - `uri` (string): Redis Connection String.
 - `nodes` (array): [Redis Cluster Configuration](https://github.com/luin/ioredis#cluster).
@@ -46,19 +46,14 @@ Options available:
 - `prefix` (string): Prefix keys in Redis.
 - `ping` (object): Configure ping to Redis DB.
 
-Buckets:
+### Buckets:
 
 - `size` (number): is the maximum content of the bucket. This is the maximum burst you allow.
 - `per_interval` (number): is the amount of tokens that the bucket receive on every interval.
 - `interval` (number): defines the interval in milliseconds.
 - `unlimited` (boolean = false): unlimited requests (skip take).
-- `skip_n_calls` (number): take will go to redis every `n` calls instead of going in every take. 
-
-Ping:
-
-- `interval` (number): represents the time between two consecutive pings. Default: 3000.
-- `maxFailedAttempts` (number): is the allowed number of failed pings before declaring the connection as dead. Default: 5.
-- `reconnectIfFailed` (boolean): indicates whether we should try to reconnect is the connection is declared dead. Default: true.
+- `skip_n_calls` (number): take will go to redis every `n` calls instead of going in every take.
+- `elevated_limits` (object): elevated limits configuration that kicks in when the bucket is empty. Please refer to the [ERL section](#ERL-Elevated-Rate-Limits) for more details.
 
 You can also define your rates using `per_second`, `per_minute`, `per_hour`, `per_day`. So `per_second: 1` is equivalent to `per_interval: 1, interval: 1000`.
 
@@ -66,6 +61,15 @@ If you omit `size`, limitdb assumes that `size` is the value of `per_interval`. 
 
 If you don't specify a filling rate with `per_interval` or any other `per_x`, the bucket is fixed and you have to manually reset it using `PUT`.
 
+### Ping:
+
+- `interval` (number): represents the time between two consecutive pings. Default: 3000.
+- `maxFailedAttempts` (number): is the allowed number of failed pings before declaring the connection as dead. Default: 5.
+- `reconnectIfFailed` (boolean): indicates whether we should try to reconnect is the connection is declared dead. Default: true.
+
+
+
+## Overrides
 You can also define `overrides` inside your type definitions as follows:
 
 ```js
@@ -109,6 +113,31 @@ overrides: {
 }
 ```
 
+## ERL (Elevated Rate Limits)
+ERL is a feature that allows you to define a different set of limits that kick in when the bucket is empty.
+The feature aims to provide a way to temporarily allow a higher rate of requests when the bucket is empty, for a limited period of time.
+
+To be able to allow its use within limitd-redis, you need to:
+1. call the `take` method with the parameter `allowERL` set to `true`.
+2. pass the `erlIsActiveKey` parameter with the identifier of the ERL activation for the bucket. This works similarly to the `key` you pass to `limitd.take`, which is the identifier of the bucket; however it's used to track the ERL activation for the bucket instead.
+3. make sure that the bucket definition has ERL configured.
+
+You can configure elevated limits inside your bucket definitions as follows:
+
+```js
+buckets = {
+  ip: {
+    size: 10,
+    per_second: 5,
+    elevated_limits: {
+      size: 100, // new bucket size. already used tokens will be deducted from current bucket content upon ERL activation.
+      per_second: 50, // new bucket refill rate. You can use all the other refill rate configurations defined above, such as per_minute, per_hour, per_interval etc.
+      erl_activation_period_seconds: 300, // for how long the ERL configuration should remain active once activated.
+    }
+  }
+}
+```
+
 ## Breaking changes from `Limitdb`
 
 * Elements will have a default TTL of a week unless specified otherwise.
@@ -116,7 +145,7 @@ overrides: {
 ## TAKE
 
 ```js
-limitd.take(type, key, [count], (err, result) => {
+limitd.take(type, key, { count, configOverride, erlIsActive, allowERL}, (err, result) => {
   console.log(result);
 });
 ```
@@ -127,13 +156,15 @@ limitd.take(type, key, [count], (err, result) => {
 -  `key`: the identifier of the bucket.
 -  `count`: the amount of tokens you need. This is optional and the default is 1.
 -  `configOverride`: caller-provided bucket configuration for this operation
+-  `erlIsActiveKey`: (string) the identifier of the ERL activation for the bucket. Only mandatory to pass while operating on buckets that have ERL configured.
+-  `allowERL`: (boolean) optional. if set to true, the ERL feature will be allowed to be used.
 
 The result object has:
-
 -  `conformant` (boolean): true if the requested amount is conformant to the limit.
 -  `remaining` (int): the amount of remaining tokens in the bucket.
 -  `reset` (int / unix timestamp): unix timestamp of the date when the bucket will be full again.
 -  `limit` (int): the size of the bucket.
+-  `erl_activated` (boolean): true if the bucket has ERL activated at the time of the request. Only returned for buckets that have ERL configured.
 
 ## PUT
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The overrides in ERL work the same way as for the regular bucket. Both size and 
 ## TAKE
 
 ```js
-limitd.take(type, key, { count, configOverride, erlIsActive, allowERL}, (err, result) => {
+limitd.take(type, key, { count, configOverride }, (err, result) => {
   console.log(result);
 });
 ```

--- a/lib/db.js
+++ b/lib/db.js
@@ -10,6 +10,7 @@ const DBPing = require("./db_ping");
 const EventEmitter = require('events').EventEmitter;
 
 const TAKE_LUA = fs.readFileSync(`${__dirname}/take.lua`, "utf8");
+const TAKE_ELEVATED_LUA = fs.readFileSync(`${__dirname}/take_elevated.lua`, "utf8");
 const PUT_LUA = fs.readFileSync(`${__dirname}/put.lua`, "utf8");
 
 const PING_SUCCESS = "successful";
@@ -89,6 +90,11 @@ class LimitDBRedis extends EventEmitter {
     this.redis.defineCommand('take', {
       numberOfKeys: 1,
       lua: TAKE_LUA
+    });
+
+    this.redis.defineCommand('takeElevated', {
+      numberOfKeys: 2,
+      lua: TAKE_ELEVATED_LUA
     });
 
     this.redis.defineCommand('put', {
@@ -200,6 +206,7 @@ class LimitDBRedis extends EventEmitter {
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
     const key = `${params.type}:${params.key}`;
+    const erlIsActiveKey = params.erlIsActiveKey; // redis' way of knowing whether erl is active or not
 
     let count = this._determineCount({
       paramsCount: params.count,
@@ -239,39 +246,71 @@ class LimitDBRedis extends EventEmitter {
           count *= (bucketKeyConfig.skip_n_calls + 1);
         }
       }
-
-
     }
 
-    this.redis.take(key,
-      bucketKeyConfig.ms_per_interval || 0,
-      bucketKeyConfig.size,
-      count,
-      Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
-      bucketKeyConfig.drip_interval || 0,
-      (err, results) => {
-        if (err) {
-          return callback(err);
-        }
-
-        const remaining = parseInt(results[0], 10);
-        const conformant = parseInt(results[1], 10) ? true : false;
-        const currentMS = parseInt(results[2], 10);
-        const reset = parseInt(results[3], 10);
-        const res = {
-          conformant,
-          remaining,
-          reset: Math.ceil(reset / 1000),
-          limit: bucketKeyConfig.size,
-          delayed: false,
-        };
-
-        if (bucketKeyConfig.skip_n_calls > 0) {
-          this.callCounts.set(key, { res, count: 0 });
-        }
-
-        return callback(null, res);
-      });
+    if (bucket.elevated_limits && params.allowERL === true) {
+      if (!erlIsActiveKey)  {
+        return callback(new Error('erlIsActiveKey is required for elevated limits'), null);
+      }
+      this.redis.takeElevated(key, erlIsActiveKey,
+          bucketKeyConfig.ms_per_interval || 0,
+          bucketKeyConfig.size,
+          count,
+          Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
+          bucketKeyConfig.drip_interval || 0,
+          bucketKeyConfig.elevated_limits.ms_per_interval || 0,
+          bucketKeyConfig.elevated_limits.size,
+          bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
+          (err, results) => {
+            if (err) {
+              return callback(err);
+            }
+            const remaining = parseInt(results[0], 10);
+            const conformant = parseInt(results[1], 10) ? true : false;
+            const currentMS = parseInt(results[2], 10);
+            const reset = parseInt(results[3], 10);
+            const erl_activated = parseInt(results[4], 10) ? true : false;
+            const res = {
+              conformant,
+              remaining,
+              reset: Math.ceil(reset / 1000),
+              limit: bucketKeyConfig.size,
+              delayed: false,
+              erl_activated,
+            };
+            if (bucketKeyConfig.skip_n_calls > 0) {
+              this.callCounts.set(key, { res, count: 0 });
+            }
+            return callback(null, res);
+          });
+    } else {
+      this.redis.take(key,
+          bucketKeyConfig.ms_per_interval || 0,
+          bucketKeyConfig.size,
+          count,
+          Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
+          bucketKeyConfig.drip_interval || 0,
+          (err, results) => {
+            if (err) {
+              return callback(err);
+            }
+            const remaining = parseInt(results[0], 10);
+            const conformant = parseInt(results[1], 10) ? true : false;
+            const currentMS = parseInt(results[2], 10);
+            const reset = parseInt(results[3], 10);
+            const res = {
+              conformant,
+              remaining,
+              reset: Math.ceil(reset / 1000),
+              limit: bucketKeyConfig.size,
+              delayed: false,
+            };
+            if (bucketKeyConfig.skip_n_calls > 0) {
+              this.callCounts.set(key, { res, count: 0 });
+            }
+            return callback(null, res);
+          });
+    }
   }
 
   /**

--- a/lib/db.js
+++ b/lib/db.js
@@ -5,7 +5,7 @@ const async = require('async');
 const LRU = require('lru-cache');
 const utils = require('./utils');
 const Redis = require('ioredis');
-const { validateParams } = require('./validation');
+const { validateParams, validateConfigIsForElevatedBucket, validateERLParams } = require('./validation');
 const DBPing = require("./db_ping");
 const EventEmitter = require('events').EventEmitter;
 
@@ -195,8 +195,9 @@ class LimitDBRedis extends EventEmitter {
    *
    * @param {takeParams} params - The params for take.
    * @param {function(Error, takeResult)} callback.
+   * @param {function(key, bucketKeyConfig, count)} takeFunc
    */
-  take(params, callback) {
+  _doTake(params, callback, takeFunc) {
     const valError = validateParams(params, this.buckets);
     if (valError) {
       return process.nextTick(callback, valError);
@@ -206,7 +207,6 @@ class LimitDBRedis extends EventEmitter {
     const bucketKeyConfig = this.bucketKeyConfig(bucket, params);
 
     const key = `${params.type}:${params.key}`;
-    const erlIsActiveKey = params.erlIsActiveKey; // redis' way of knowing whether erl is active or not
 
     let count = this._determineCount({
       paramsCount: params.count,
@@ -248,69 +248,89 @@ class LimitDBRedis extends EventEmitter {
       }
     }
 
-    if (bucket.elevated_limits && params.allowERL === true) {
-      if (!erlIsActiveKey)  {
-        return callback(new Error('erlIsActiveKey is required for elevated limits'), null);
-      }
-      this.redis.takeElevated(key, erlIsActiveKey,
-          bucketKeyConfig.ms_per_interval || 0,
-          bucketKeyConfig.size,
-          count,
-          Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
-          bucketKeyConfig.drip_interval || 0,
-          bucketKeyConfig.elevated_limits.ms_per_interval || 0,
-          bucketKeyConfig.elevated_limits.size,
-          bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
-          (err, results) => {
-            if (err) {
-              return callback(err);
-            }
-            const remaining = parseInt(results[0], 10);
-            const conformant = parseInt(results[1], 10) ? true : false;
-            const currentMS = parseInt(results[2], 10);
-            const reset = parseInt(results[3], 10);
-            const erl_activated = parseInt(results[4], 10) ? true : false;
-            const res = {
-              conformant,
-              remaining,
-              reset: Math.ceil(reset / 1000),
-              limit: bucketKeyConfig.size,
-              delayed: false,
-              erl_activated,
-            };
-            if (bucketKeyConfig.skip_n_calls > 0) {
-              this.callCounts.set(key, { res, count: 0 });
-            }
-            return callback(null, res);
-          });
-    } else {
+    takeFunc(key, bucketKeyConfig, count)
+  }
+
+  /**
+   * Take N elements from a bucket if available.
+   *
+   * @param {takeParams} params - The params for take.
+   * @param {function(Error, takeResult)} callback.
+   */
+  take(params, callback) {
+    this._doTake(params, callback, (key, bucketKeyConfig, count) => {
       this.redis.take(key,
-          bucketKeyConfig.ms_per_interval || 0,
-          bucketKeyConfig.size,
-          count,
-          Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
-          bucketKeyConfig.drip_interval || 0,
-          (err, results) => {
-            if (err) {
-              return callback(err);
-            }
-            const remaining = parseInt(results[0], 10);
-            const conformant = parseInt(results[1], 10) ? true : false;
-            const currentMS = parseInt(results[2], 10);
-            const reset = parseInt(results[3], 10);
-            const res = {
-              conformant,
-              remaining,
-              reset: Math.ceil(reset / 1000),
-              limit: bucketKeyConfig.size,
-              delayed: false,
-            };
-            if (bucketKeyConfig.skip_n_calls > 0) {
-              this.callCounts.set(key, { res, count: 0 });
-            }
-            return callback(null, res);
-          });
+        bucketKeyConfig.ms_per_interval || 0,
+        bucketKeyConfig.size,
+        count,
+        Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
+        bucketKeyConfig.drip_interval || 0,
+        (err, results) => {
+          if (err) {
+            return callback(err);
+          }
+          const remaining = parseInt(results[0], 10);
+          const conformant = parseInt(results[1], 10) ? true : false;
+          const currentMS = parseInt(results[2], 10);
+          const reset = parseInt(results[3], 10);
+          const res = {
+            conformant,
+            remaining,
+            reset: Math.ceil(reset / 1000),
+            limit: bucketKeyConfig.size,
+            delayed: false,
+          };
+          if (bucketKeyConfig.skip_n_calls > 0) {
+            this.callCounts.set(key, { res, count: 0 });
+          }
+          return callback(null, res);
+        });
+    })
+  }
+
+  takeElevated(params, callback) {
+    const valError = validateERLParams(params);
+    if (valError) {
+      return callback(valError)
     }
+
+    this._doTake(params, callback, (key, bucketKeyConfig, count) => {
+      const valError = validateConfigIsForElevatedBucket(key, bucketKeyConfig)
+      if (valError) {
+        return callback(valError)
+      }
+      this.redis.takeElevated(key, params.erlIsActiveKey,
+        bucketKeyConfig.ms_per_interval || 0,
+        bucketKeyConfig.size,
+        count,
+        Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
+        bucketKeyConfig.drip_interval || 0,
+        bucketKeyConfig.elevated_limits.ms_per_interval || 0,
+        bucketKeyConfig.elevated_limits.size,
+        bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
+        (err, results) => {
+          if (err) {
+            return callback(err);
+          }
+          const remaining = parseInt(results[0], 10);
+          const conformant = parseInt(results[1], 10) ? true : false;
+          const currentMS = parseInt(results[2], 10);
+          const reset = parseInt(results[3], 10);
+          const erl_activated = parseInt(results[4], 10) ? true : false;
+          const res = {
+            conformant,
+            remaining,
+            reset: Math.ceil(reset / 1000),
+            limit: bucketKeyConfig.size,
+            delayed: false,
+            erl_activated,
+          };
+          if (bucketKeyConfig.skip_n_calls > 0) {
+            this.callCounts.set(key, { res, count: 0 });
+          }
+          return callback(null, res);
+        });
+    })
   }
 
   /**

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -1,0 +1,98 @@
+local tokens_per_ms               = tonumber(ARGV[1])
+local bucket_size                 = tonumber(ARGV[2])
+local tokens_to_take              = tonumber(ARGV[3])
+local ttl                         = tonumber(ARGV[4])
+local drip_interval               = tonumber(ARGV[5])
+local erl_tokens_per_ms           = tonumber(ARGV[6])
+local erl_bucket_size             = tonumber(ARGV[7])
+local erl_activation_period_seconds  = tonumber(ARGV[8])
+
+-- the key to use for pulling last bucket state from redis
+local lastBucketStateKey = KEYS[1]
+
+-- the key for checking in redis if elevated rate limits (erl) were activated earlier
+local erlKey = KEYS[2]
+local is_erl_activated = redis.call('EXISTS', erlKey)
+
+-- get current bucket state
+local current = redis.pcall('HMGET', lastBucketStateKey, 'd', 'r')
+if current.err ~= nil then
+    current = {}
+end
+
+-- get current time from redis, to be used in new bucket size calculations later
+local current_time = redis.call('TIME')
+local current_timestamp_ms = current_time[1] * 1000 + current_time[2] / 1000
+
+local function calculateNewBucketContent(current, tokens_per_ms, bucket_size, current_timestamp_ms)
+    if current[1] and tokens_per_ms then
+        -- drip bucket
+        local last_drip = current[1]
+        local content = current[2]
+        local delta_ms = math.max(current_timestamp_ms - last_drip, 0)
+        local drip_amount = delta_ms * tokens_per_ms
+        return math.min(content + drip_amount, bucket_size)
+    elseif current[1] and tokens_per_ms == 0 then
+        -- fixed bucket
+        return current[2]
+    else
+        -- first take of the bucket
+        return bucket_size
+    end
+end
+
+-- Enable verbatim replication to ensure redis sends script's source code to all masters
+-- managing the sharded database in a clustered deployment.
+-- https://redis.io/docs/interact/programmability/eval-intro/#:~:text=scripts%20debugger.-,Script%20replication,-In%20standalone%20deployments
+redis.replicate_commands()
+
+-- calculate new bucket content
+local bucket_content_after_refill
+if is_erl_activated==1 then
+    bucket_content_after_refill = calculateNewBucketContent(current, erl_tokens_per_ms, erl_bucket_size, current_timestamp_ms)
+else
+    bucket_content_after_refill = calculateNewBucketContent(current, tokens_per_ms, bucket_size, current_timestamp_ms)
+end
+
+local enough_tokens = bucket_content_after_refill >= tokens_to_take
+local bucket_content_after_take = bucket_content_after_refill
+
+if enough_tokens then
+    if is_erl_activated == 1 then
+        bucket_content_after_take = math.min(bucket_content_after_refill - tokens_to_take, erl_bucket_size)
+    else
+        bucket_content_after_take = math.min(bucket_content_after_refill - tokens_to_take, bucket_size)
+    end
+else
+    -- if tokens are not enough, see if activating erl will help.
+    if is_erl_activated == 0 then
+        local used_tokens = bucket_size - bucket_content_after_refill
+        local bucket_content_after_erl_activation = erl_bucket_size - used_tokens
+        local enough_tokens_after_erl_activation = bucket_content_after_erl_activation >= tokens_to_take
+        if enough_tokens_after_erl_activation then
+            enough_tokens = enough_tokens_after_erl_activation -- we are returning this value, thus setting it
+            bucket_content_after_take = math.min(bucket_content_after_erl_activation - tokens_to_take, erl_bucket_size)
+            -- save erl state
+            redis.call('SET', erlKey, '1')
+            redis.call('EXPIRE', erlKey, erl_activation_period_seconds)
+            is_erl_activated = 1
+        end
+    end
+end
+
+-- save bucket state
+redis.call('HMSET', lastBucketStateKey,
+            'd', current_timestamp_ms,
+            'r', bucket_content_after_take)
+redis.call('EXPIRE', lastBucketStateKey, ttl)
+
+local reset_ms = 0
+if drip_interval > 0 then
+    if is_erl_activated == 1 then
+        reset_ms = math.ceil(current_timestamp_ms + (erl_bucket_size - bucket_content_after_take) * drip_interval)
+    else
+        reset_ms = math.ceil(current_timestamp_ms + (bucket_size - bucket_content_after_take) * drip_interval)
+    end
+end
+
+return { bucket_content_after_take, enough_tokens, current_timestamp_ms, reset_ms, is_erl_activated }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,8 +18,7 @@ function normalizeTemporals(params) {
     'interval',
     'size',
     'unlimited',
-    'skip_n_calls',
-    'erl_activation_period_seconds'
+    'skip_n_calls'
   ]);
 
   INTERVAL_SHORTCUTS.forEach(intervalShortcut => {
@@ -39,10 +38,23 @@ function normalizeTemporals(params) {
   }
 
   if (params.elevated_limits) {
-    type.elevated_limits = normalizeTemporals(params.elevated_limits);
+    type.elevated_limits = normalizeElevatedTemporals(params.elevated_limits);
   }
-  if (!type.erl_activation_period_seconds) {
+
+  return type;
+}
+
+function normalizeElevatedTemporals(params) {
+  if (!params) {
+    return;
+  }
+
+  let type = normalizeTemporals(params);
+
+  if (!params.erl_activation_period_seconds) {
     type.erl_activation_period_seconds = ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS;
+  } else {
+    type.erl_activation_period_seconds = params.erl_activation_period_seconds;
   }
 
   return type;
@@ -50,9 +62,6 @@ function normalizeTemporals(params) {
 
 function normalizeType(params) {
   const type = normalizeTemporals(params);
-  if (params.elevated_limits) {
-    type.elevated_limits = normalizeTemporals(params.elevated_limits);
-  }
 
   type.overridesMatch = {};
   type.overrides = _.reduce(params.overrides || params.override, (result, overrideDef, name) => {
@@ -65,6 +74,11 @@ function normalizeType(params) {
     if (overrideDef.match) {
       // TODO: Allow more flags
       override.match = new RegExp(overrideDef.match, 'i');
+    }
+
+    // If the override doesn't provide elevated_limits use the ones defined in the upper level (if any)
+    if (!override.elevated_limits && type.elevated_limits) {
+      override.elevated_limits = type.elevated_limits;
     }
 
     if (!override.until || override.until >= new Date()) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,6 +10,7 @@ const INTERVAL_TO_MS = {
 };
 
 const INTERVAL_SHORTCUTS = Object.keys(INTERVAL_TO_MS);
+const ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS = 15 * 60;
 
 function normalizeTemporals(params) {
   const type = _.pick(params, [
@@ -17,7 +18,8 @@ function normalizeTemporals(params) {
     'interval',
     'size',
     'unlimited',
-    'skip_n_calls'
+    'skip_n_calls',
+    'erl_activation_period_seconds'
   ]);
 
   INTERVAL_SHORTCUTS.forEach(intervalShortcut => {
@@ -36,11 +38,21 @@ function normalizeTemporals(params) {
     type.drip_interval = type.interval / type.per_interval;
   }
 
+  if (params.elevated_limits) {
+    type.elevated_limits = normalizeTemporals(params.elevated_limits);
+  }
+  if (!type.erl_activation_period_seconds) {
+    type.erl_activation_period_seconds = ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS;
+  }
+
   return type;
 }
 
 function normalizeType(params) {
   const type = normalizeTemporals(params);
+  if (params.elevated_limits) {
+    type.elevated_limits = normalizeTemporals(params.elevated_limits);
+  }
 
   type.overridesMatch = {};
   type.overrides = _.reduce(params.overrides || params.override, (result, overrideDef, name) => {
@@ -112,5 +124,6 @@ module.exports = {
   normalizeTemporals,
   normalizeType,
   functionOrFalse,
-  randomBetween
+  randomBetween,
+  ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS: ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS,
 };

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,4 +1,5 @@
 const { INTERVAL_SHORTCUTS } = require('./utils');
+const {util} = require('chai');
 
 class LimitdRedisValidationError extends Error {
   constructor(msg, extra) {
@@ -58,7 +59,31 @@ function validateOverride(configOverride) {
   }
 }
 
+function validateERLParams(params) {
+  const erlIsActiveKey = params.erlIsActiveKey; // redis' way of knowing whether erl is active or not
+  if (!erlIsActiveKey)  {
+    return new LimitdRedisValidationError('erlIsActiveKey is required for elevated limits', { code: 107 });
+  }
+}
+
+function validateConfigIsForElevatedBucket(key, bucketKeyConfig) {
+  if (!isConfigForElevatedBucket(bucketKeyConfig)) {
+    return new LimitdRedisValidationError(`Attempted to takeElevated() for a bucket with no elevated config. bucket:${key}, bucketKeyConfig:${util.inspect(bucketKeyConfig)}`,
+      { code: 108 });
+  }
+}
+
+function isConfigForElevatedBucket(bucketKeyConfig) {
+  return bucketKeyConfig.elevated_limits
+    && bucketKeyConfig.elevated_limits.size
+    && bucketKeyConfig.elevated_limits.per_interval
+    && bucketKeyConfig.elevated_limits.erl_activation_period_seconds;
+
+}
+
 module.exports = {
   validateParams,
+  validateERLParams,
+  validateConfigIsForElevatedBucket,
   LimitdRedisValidationError,
 };

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,5 +1,4 @@
 const { INTERVAL_SHORTCUTS } = require('./utils');
-const {util} = require('chai');
 
 class LimitdRedisValidationError extends Error {
   constructor(msg, extra) {
@@ -68,7 +67,7 @@ function validateERLParams(params) {
 
 function validateConfigIsForElevatedBucket(key, bucketKeyConfig) {
   if (!isConfigForElevatedBucket(bucketKeyConfig)) {
-    return new LimitdRedisValidationError(`Attempted to takeElevated() for a bucket with no elevated config. bucket:${key}, bucketKeyConfig:${util.inspect(bucketKeyConfig)}`,
+    return new LimitdRedisValidationError(`Attempted to takeElevated() for a bucket with no elevated config. bucket:${key}, bucketKeyConfig:${JSON.stringify(bucketKeyConfig)}`,
       { code: 108 });
   }
 }

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -81,6 +81,37 @@ const buckets = {
   },
 };
 
+const elevatedBuckets = {
+  ip: {
+    ...buckets.ip,
+    elevated_limits: {
+      size: buckets.ip.size,
+      per_minute: buckets.ip.per_second,
+    },
+  },
+  user: {
+    ...buckets.user,
+    elevated_limits: {
+      size: buckets.user.size,
+      per_minute: buckets.user.per_second,
+    },
+  },
+  global: {
+    ...buckets.global,
+    elevated_limits: {
+      size: buckets.global.size,
+      per_minute: buckets.global.per_hour,
+    },
+  },
+  tenant: {
+    ...buckets.tenant,
+    elevated_limits: {
+      size: buckets.tenant.size,
+      per_minute: buckets.tenant.per_second,
+    },
+  },
+}
+
 describe('LimitDBRedis', () => {
   let db;
 
@@ -93,7 +124,6 @@ describe('LimitDBRedis', () => {
   });
 
   afterEach((done) => {
-
     db.close((err) => {
       // Can't close DB if it was never open
       if (err?.message.indexOf('enableOfflineQueue') > 0) {
@@ -136,70 +166,112 @@ describe('LimitDBRedis', () => {
   });
 
   describe('TAKE', () => {
-    it('should fail on validation', (done) => {
-      db.take({}, (err) => {
-        assert.match(err.message, /type is required/);
-        done();
-      });
-    });
+    const testsParams = [
+      {
+        name: 'regular take',
+        init: () => {},
+        take: (params, callback) => db.take(params, callback),
+        params: {}
+      },
+      {
+        name: 'elevated take',
+        init: () => db.configurateBuckets(elevatedBuckets),
+        take: (params, callback) => db.takeElevated(params, callback),
+        params: { erlIsActiveKey: 'some_erl_active_identifier' }
+      }
+    ]
 
-    it('should keep track of a key', (done) => {
-      const params = { type: 'ip',  key: '21.17.65.41'};
-      db.take(params, (err) => {
-        if (err) {
-          return done(err);
-        }
-        db.take(params, (err, result) => {
-          if (err) {
-            return done(err);
-          }
-          assert.equal(result.conformant, true);
-          assert.equal(result.remaining, 8);
-          done();
+    testsParams.forEach(testParams => {
+      describe(`${testParams.name}`, () => {
+        it(`should fail on validation`, (done) => {
+          testParams.init();
+          testParams.take({...testParams.params}, (err) => {
+            assert.match(err.message, /type is required/);
+            done();
+          });
         });
-      });
-    });
 
-    it('should add a ttl to buckets', (done) => {
-      const params = { type: 'ip', key: '211.45.66.1'};
-      db.take(params, (err) => {
-        if (err) {
-          return done(err);
-        }
-        db.redis.ttl(`${params.type}:${params.key}`, (err, ttl) => {
-          if (err) {
-            return done(err);
-          }
-          assert.equal(db.buckets['ip'].ttl, ttl);
-          done();
-        });
-      });
-    });
-
-    it('should return TRUE with right remaining and reset after filling up the bucket', (done) => {
-      const now = Date.now();
-      db.take({
-        type: 'ip',
-        key:  '5.5.5.5'
-      }, (err) => {
-        if (err) {
-          return done(err);
-        }
-        db.put({
-          type: 'ip',
-          key:  '5.5.5.5',
-        }, (err) => {
-          if (err) {
-            return done(err);
-          }
-          db.take({
-            type: 'ip',
-            key:  '5.5.5.5'
-          }, (err, result) => {
+        it(`should keep track of a key`, (done) => {
+          testParams.init();
+          const params = {...testParams.params, type: 'ip',  key: '21.17.65.41'};
+          testParams.take(params, (err) => {
             if (err) {
               return done(err);
             }
+            testParams.take(params, (err, result) => {
+              if (err) {
+                return done(err);
+              }
+              assert.equal(result.conformant, true);
+              assert.equal(result.remaining, 8);
+              done();
+            });
+          });
+        });
 
+        it(`should add a ttl to buckets`, (done) => {
+          testParams.init();
+          const params = {...testParams.params, type: 'ip', key: '211.45.66.1'};
+          testParams.take(params, (err) => {
+            if (err) {
+              return done(err);
+            }
+            db.redis.ttl(`${params.type}:${params.key}`, (err, ttl) => {
+              if (err) {
+                return done(err);
+              }
+              assert.equal(db.buckets['ip'].ttl, ttl);
+              done();
+            });
+          });
+        });
+
+        it(`should return TRUE with right remaining and reset after filling up the bucket`, (done) => {
+          testParams.init();
+          const now = Date.now();
+          testParams.take({
+            ...testParams.params,
+            type: 'ip',
+            key:  '5.5.5.5'
+          }, (err) => {
+            if (err) {
+              return done(err);
+            }
+            db.put({
+              type: 'ip',
+              key:  '5.5.5.5',
+            }, (err) => {
+              if (err) {
+                return done(err);
+              }
+              testParams.take({
+                ...testParams.params,
+                type: 'ip',
+                key:  '5.5.5.5'
+              }, (err, result) => {
+                if (err) {
+                  return done(err);
+                }
+
+                assert.ok(result.conformant);
+                assert.equal(result.remaining, 9);
+                assert.closeTo(result.reset, now / 1000, 3);
+                assert.equal(result.limit, 10);
+                done();
+              });
+            });
+          });
+        });
+
+        it(`should return TRUE when traffic is conformant`, (done) => {
+          testParams.init();
+          const now = Date.now();
+          testParams.take({
+            ...testParams.params,
+            type: 'ip',
+            key:  '1.1.1.1'
+          }, (err, result) => {
+            if (err) return done(err);
             assert.ok(result.conformant);
             assert.equal(result.remaining, 9);
             assert.closeTo(result.reset, now / 1000, 3);
@@ -207,245 +279,393 @@ describe('LimitDBRedis', () => {
             done();
           });
         });
-      });
-    });
 
-    it('should return TRUE when traffic is conformant', (done) => {
-      const now = Date.now();
-      db.take({
-        type: 'ip',
-        key:  '1.1.1.1'
-      }, (err, result) => {
-        if (err) return done(err);
-        assert.ok(result.conformant);
-        assert.equal(result.remaining, 9);
-        assert.closeTo(result.reset, now / 1000, 3);
-        assert.equal(result.limit, 10);
-        done();
-      });
-    });
-
-    it('should return FALSE when requesting more than the size of the bucket', (done) => {
-      const now = Date.now();
-      db.take({
-        type:  'ip',
-        key:   '2.2.2.2',
-        count: 12
-      }, (err, result) => {
-        if (err) return done(err);
-        assert.notOk(result.conformant);
-        assert.equal(result.remaining, 10);
-        assert.closeTo(result.reset, now / 1000, 3);
-        assert.equal(result.limit, 10);
-        done();
-      });
-    });
-
-    it('should return FALSE when traffic is not conformant', (done) => {
-      const takeParams = {
-        type:  'ip',
-        key:   '3.3.3.3'
-      };
-      async.map(_.range(10), (i, done) => {
-        db.take(takeParams, done);
-      }, (err, responses) => {
-        if (err) return done(err);
-        assert.ok(responses.every((r) => { return r.conformant; }));
-        db.take(takeParams, (err, response) => {
-          assert.notOk(response.conformant);
-          assert.equal(response.remaining, 0);
-          done();
+        it(`should return FALSE when requesting more than the size of the bucket`, (done) => {
+          testParams.init();
+          const now = Date.now();
+          testParams.take({
+            ...testParams.params,
+            type:  'ip',
+            key:   '2.2.2.2',
+            count: 12
+          }, (err, result) => {
+            if (err) return done(err);
+            assert.notOk(result.conformant);
+            assert.equal(result.remaining, 10);
+            assert.closeTo(result.reset, now / 1000, 3);
+            assert.equal(result.limit, 10);
+            done();
+          });
         });
-      });
-    });
 
-    it('should return TRUE if an override by name allows more', (done) => {
-      const takeParams = {
-        type:  'ip',
-        key:   '127.0.0.1'
-      };
-      async.each(_.range(10), (i, done) => {
-        db.take(takeParams, done);
-      }, (err) => {
-        if (err) return done(err);
-        db.take(takeParams, (err, result) => {
-          if (err) return done(err);
-          assert.ok(result.conformant);
-          assert.ok(result.remaining, 89);
-          done();
+        it(`should return FALSE when traffic is not conformant`, (done) => {
+          testParams.init();
+          const takeParams = {
+            ...testParams.params,
+            type:  'ip',
+            key:   '3.3.3.3'
+          };
+          async.map(_.range(10), (i, done) => {
+            testParams.take(takeParams, done);
+          }, (err, responses) => {
+            if (err) return done(err);
+            assert.ok(responses.every((r) => { return r.conformant; }));
+            testParams.take(takeParams, (err, response) => {
+              assert.notOk(response.conformant);
+              assert.equal(response.remaining, 0);
+              done();
+            });
+          });
         });
-      });
-    });
 
-    it('should return TRUE if an override allows more', (done) => {
-      const takeParams = {
-        type:  'ip',
-        key:   '192.168.0.1'
-      };
-      async.each(_.range(10), (i, done) => {
-        db.take(takeParams, done);
-      }, (err) => {
-        if (err) return done(err);
-        db.take(takeParams, (err, result) => {
-          assert.ok(result.conformant);
-          assert.ok(result.remaining, 39);
-          done();
+        it(`should return TRUE if an override by name allows more`, (done) => {
+          testParams.init();
+          const takeParams = {
+            ...testParams.params,
+            type:  'ip',
+            key:   '127.0.0.1'
+          };
+          async.each(_.range(10), (i, done) => {
+            testParams.take(takeParams, done);
+          }, (err) => {
+            if (err) return done(err);
+            testParams.take(takeParams, (err, result) => {
+              if (err) return done(err);
+              assert.ok(result.conformant);
+              assert.ok(result.remaining, 89);
+              done();
+            });
+          });
         });
-      });
-    });
 
-    it('can expire an override', (done) => {
-      const takeParams = {
-        type: 'ip',
-        key:  '10.0.0.123'
-      };
-      async.each(_.range(10), (i, cb) => {
-        db.take(takeParams, cb);
-      }, (err) => {
-        if (err) {
-          return done(err);
-        }
-        db.take(takeParams, (err, response) => {
-          assert.notOk(response.conformant);
-          done();
+        it(`should return TRUE if an override allows more`, (done) => {
+          testParams.init();
+          const takeParams = {
+            ...testParams.params,
+            type:  'ip',
+            key:   '192.168.0.1'
+          };
+          async.each(_.range(10), (i, done) => {
+            testParams.take(takeParams, done);
+          }, (err) => {
+            if (err) return done(err);
+            testParams.take(takeParams, (err, result) => {
+              assert.ok(result.conformant);
+              assert.ok(result.remaining, 39);
+              done();
+            });
+          });
         });
-      });
-    });
 
-    it('can parse a date and expire and override', (done) => {
-      const takeParams = {
-        type: 'ip',
-        key:  '10.0.0.124'
-      };
-      async.each(_.range(10), (i, cb) => {
-        db.take(takeParams, cb);
-      }, (err) => {
-        if (err) {
-          return done(err);
-        }
-        db.take(takeParams, (err, response) => {
-          assert.notOk(response.conformant);
-          done();
+        it(`can expire an override`, (done) => {
+          testParams.init();
+          const takeParams = {
+            ...testParams.params,
+            type: 'ip',
+            key:  '10.0.0.123'
+          };
+          async.each(_.range(10), (i, cb) => {
+            testParams.take(takeParams, cb);
+          }, (err) => {
+            if (err) {
+              return done(err);
+            }
+            testParams.take(takeParams, (err, response) => {
+              assert.notOk(response.conformant);
+              done();
+            });
+          });
         });
-      });
-    });
 
-    it('should use seconds ceiling for next reset', (done) => {
-      // it takes ~1790 msec to fill the bucket with this test
-      const now = Date.now();
-      const requests = _.range(9).map(() => {
-        return cb => db.take({ type: 'ip', key: '211.123.12.36' }, cb);
-      });
-      async.series(requests, (err, results) => {
-        if (err) return done(err);
-        const lastResult = results[results.length -1];
-        assert.ok(lastResult.conformant);
-        assert.equal(lastResult.remaining, 1);
-        assert.closeTo(lastResult.reset, now / 1000, 3);
-        assert.equal(lastResult.limit, 10);
-        done();
-      });
-    });
-
-    it('should set reset to UNIX timestamp regardless of period', (done) => {
-      const now = Date.now();
-      db.take({ type: 'ip', key: '10.0.0.1' }, (err, result) => {
-        if (err) { return done(err); }
-        assert.ok(result.conformant);
-        assert.equal(result.remaining, 0);
-        assert.closeTo(result.reset, now / 1000 + 1800, 1);
-        assert.equal(result.limit, 1);
-        done();
-      });
-    });
-
-    it('should work for unlimited', (done) => {
-      const now = Date.now();
-      db.take({ type: 'ip', key: '0.0.0.0' }, (err, response) => {
-        if (err) return done(err);
-        assert.ok(response.conformant);
-        assert.equal(response.remaining, 100);
-        assert.closeTo(response.reset, now / 1000, 1);
-        assert.equal(response.limit, 100);
-        done();
-      });
-    });
-
-    it('should work with a fixed bucket', (done) => {
-      async.map(_.range(10), (i, done) => {
-        db.take({ type: 'ip', key: '8.8.8.8' }, done);
-      }, (err, results) => {
-        if (err) return done(err);
-        results.forEach((r, i) => {
-          assert.equal(r.remaining + i + 1, 10);
+        it(`can parse a date and expire and override`, (done) => {
+          testParams.init();
+          const takeParams = {
+            ...testParams.params,
+            type: 'ip',
+            key:  '10.0.0.124'
+          };
+          async.each(_.range(10), (i, cb) => {
+            testParams.take(takeParams, cb);
+          }, (err) => {
+            if (err) {
+              return done(err);
+            }
+            testParams.take(takeParams, (err, response) => {
+              assert.notOk(response.conformant);
+              done();
+            });
+          });
         });
-        assert.ok(results.every(r => r.conformant));
-        db.take({ type: 'ip', key: '8.8.8.8' }, (err, response) => {
-          assert.notOk(response.conformant);
-          done();
+
+        it(`should use seconds ceiling for next reset`, (done) => {
+          testParams.init();
+          // it takes ~1790 msec to fill the bucket with this test
+          const now = Date.now();
+          const requests = _.range(9).map(() => {
+            return cb => testParams.take({...testParams.params, type: 'ip', key: '211.123.12.36' }, cb);
+          });
+          async.series(requests, (err, results) => {
+            if (err) return done(err);
+            const lastResult = results[results.length -1];
+            assert.ok(lastResult.conformant);
+            assert.equal(lastResult.remaining, 1);
+            assert.closeTo(lastResult.reset, now / 1000, 3);
+            assert.equal(lastResult.limit, 10);
+            done();
+          });
         });
-      });
-    });
 
-    it('should work with RegExp', (done) => {
-      db.take({ type: 'user', key: 'regexp|test'}, (err, response) => {
-        if (err) {
-          return done(err);
-        }
-        assert.ok(response.conformant);
-        assert.equal(response.remaining, 9);
-        assert.equal(response.limit, 10);
-        done();
-      });
-    });
+        it(`should set reset to UNIX timestamp regardless of period`, (done) => {
+          testParams.init();
+          const now = Date.now();
+          testParams.take({...testParams.params, type: 'ip', key: '10.0.0.1' }, (err, result) => {
+            if (err) { return done(err); }
+            assert.ok(result.conformant);
+            assert.equal(result.remaining, 0);
+            assert.closeTo(result.reset, now / 1000 + 1800, 1);
+            assert.equal(result.limit, 1);
+            done();
+          });
+        });
 
-    it('should work with "all"', (done) => {
-      db.take({ type: 'user', key: 'regexp|test', count: 'all'}, (err, response) => {
-        if (err) {
-          return done(err);
-        }
-        assert.ok(response.conformant);
-        assert.equal(response.remaining, 0);
-        assert.equal(response.limit, 10);
-        done();
-      });
-    });
+        it(`should work for unlimited`, (done) => {
+          testParams.init();
+          const now = Date.now();
+          testParams.take({...testParams.params, type: 'ip', key: '0.0.0.0' }, (err, response) => {
+            if (err) return done(err);
+            assert.ok(response.conformant);
+            assert.equal(response.remaining, 100);
+            assert.closeTo(response.reset, now / 1000, 1);
+            assert.equal(response.limit, 100);
+            done();
+          });
+        });
 
-    it('should work with count=0', (done) => {
-      db.take({ type: 'ip', key: '9.8.7.6', count: 0 }, (err, response) => {
-        if (err) {
-          return done(err);
-        }
-        assert.ok(response.conformant);
-        assert.equal(response.remaining, 200);
-        assert.equal(response.limit, 200);
-        done();
-      });
-    });
+        it(`should work with a fixed bucket`, (done) => {
+          testParams.init();
+          async.map(_.range(10), (i, done) => {
+            testParams.take({...testParams.params, type: 'ip', key: '8.8.8.8' }, done);
+          }, (err, results) => {
+            if (err) return done(err);
+            results.forEach((r, i) => {
+              assert.equal(r.remaining + i + 1, 10);
+            });
+            assert.ok(results.every(r => r.conformant));
+            testParams.take({...testParams.params, type: 'ip', key: '8.8.8.8' }, (err, response) => {
+              assert.notOk(response.conformant);
+              done();
+            });
+          });
+        });
 
-    [
-      '0',
-      0.5,
-      'ALL',
-      true,
-      1n,
-      {},
-    ].forEach((count) => {
-      it(`should not work for non-integer count=${count}`, (done) => {
-        const opts = {
-          type: 'ip',
-          key: '9.8.7.6',
-          count,
-        };
+        it(`should work with RegExp`, (done) => {
+          testParams.init();
+          testParams.take({...testParams.params, type: 'user', key: 'regexp|test'}, (err, response) => {
+            if (err) {
+              return done(err);
+            }
+            assert.ok(response.conformant);
+            assert.equal(response.remaining, 9);
+            assert.equal(response.limit, 10);
+            done();
+          });
+        });
 
-        assert.throws(() => db.take(opts, () => {}), /if provided, count must be 'all' or an integer value/);
-        done();
-      });
-    });
+        it(`should work with "all"`, (done) => {
+          testParams.init();
+          testParams.take({...testParams.params, type: 'user', key: 'regexp|test', count: 'all'}, (err, response) => {
+            if (err) {
+              return done(err);
+            }
+            assert.ok(response.conformant);
+            assert.equal(response.remaining, 0);
+            assert.equal(response.limit, 10);
+            done();
+          });
+        });
+
+        it(`should work with count=0`, (done) => {
+          testParams.init();
+          testParams.take({...testParams.params, type: 'ip', key: '9.8.7.6', count: 0 }, (err, response) => {
+            if (err) {
+              return done(err);
+            }
+            assert.ok(response.conformant);
+            assert.equal(response.remaining, 200);
+            assert.equal(response.limit, 200);
+            done();
+          });
+        });
+
+        [
+          '0',
+          0.5,
+          'ALL',
+          true,
+          1n,
+          {},
+        ].forEach((count) => {
+          it(`should not work for non-integer count=${count}`, (done) => {
+            testParams.init();
+            const opts = {
+              ...testParams.params,
+              type: 'ip',
+              key: '9.8.7.6',
+              count,
+            };
+
+            assert.throws(() => testParams.take(opts, () => {}), /if provided, count must be 'all' or an integer value/);
+            done();
+          });
+        });
+
+        it(`should call redis and not set local cache count`, (done) => {
+          testParams.init();
+          const params = {...testParams.params, type: 'global',  key: 'aTenant'};
+          testParams.take(params, (err) => {
+            if (err) {
+              return done(err);
+            }
+
+            assert.equal(db.callCounts['global:aTenant'], undefined);
+            done();
+          });
+        });
+
+        describe(`${testParams.name} skip calls`, () => {
+          it('should skip calls', (done) => {
+            testParams.init();
+            const params = {...testParams.params, type: 'global',  key: 'skipit'};
+
+            async.series([
+              (cb) => testParams.take(params, cb), // redis
+              (cb) => testParams.take(params, cb), // cache
+              (cb) => testParams.take(params, cb), // cache
+              (cb) => {
+                assert.equal(db.callCounts.get('global:skipit').count, 2);
+                cb();
+              },
+              (cb) => testParams.take(params, cb), // redis
+              (cb) => testParams.take(params, cb), // cache
+              (cb) => testParams.take(params, cb), // cache
+              (cb) => testParams.take(params, cb), // redis (first nonconformant)
+              (cb) => testParams.take(params, cb), // cache (first cached)
+              (cb) => {
+                assert.equal(db.callCounts.get('global:skipit').count, 1);
+                assert.notOk(db.callCounts.get('global:skipit').res.conformant);
+                cb();
+              },
+            ], (err, _results) => {
+              if (err) {
+                return done(err);
+              }
+
+              done();
+            })
+          });
+
+          it('should take correct number of tokens for skipped calls with single count', (done) => {
+            testParams.init();
+            const params = {...testParams.params, type: 'global',  key: 'skipOneSize3'};
+
+            // size = 3
+            // skip_n_calls = 1
+            // no refill
+            async.series([
+              (cb) => db.get(params, (_, {remaining}) => { assert.equal(remaining, 3); cb(); }),
+
+              // call 1 - redis
+              // takes 1 token
+              (cb) => testParams.take(params, (_, { remaining, conformant }) => {
+                assert.equal(remaining, 2);
+                assert.ok(conformant)
+                cb();
+              }),
+
+              // call 2 - skipped
+              (cb) => testParams.take(params, (_, { remaining, conformant }) => {
+                assert.equal(remaining, 2);
+                assert.ok(conformant)
+                cb();
+              }),
+
+              // call 3 - redis
+              // takes 2 tokens here, 1 for current call and one for previously skipped call
+              (cb) => testParams.take(params, (_, { remaining, conformant }) => {
+                assert.equal(remaining, 0);
+                assert.ok(conformant)
+                cb();
+              }),
+
+              // call 4 - skipped
+              // Note: this is the margin of error introduced by skip_n_calls. Without skip_n_calls, this call would be
+              // non-conformant.
+              (cb) => testParams.take(params, (_, { remaining, conformant }) => {
+                assert.equal(remaining, 0);
+                assert.ok(conformant);
+                cb();
+              }),
+
+              // call 5 - redis
+              (cb) => testParams.take(params, (_, { remaining, conformant }) => {
+                assert.equal(remaining, 0);
+                assert.notOk(conformant);
+                cb();
+              }),
+            ], (err, _results) => {
+              if (err) {
+                return done(err);
+              }
+              done();
+            })
+          });
+
+          it('should take correct number of tokens for skipped calls with multi count', (done) => {
+            testParams.init();
+            const params = {...testParams.params, type: 'global',  key: 'skipOneSize10', count: 2};
+
+            // size = 10
+            // skip_n_calls = 1
+            // no refill
+            async.series([
+              (cb) => db.get(params, (_, {remaining}) => { assert.equal(remaining, 10); cb(); }),
+
+              // call 1 - redis
+              // takes 2 tokens
+              (cb) => testParams.take(params, (_, { remaining, conformant }) => {
+                assert.equal(remaining, 8);
+                assert.ok(conformant)
+                cb();
+              }),
+
+              // call 2 - skipped
+              (cb) => testParams.take(params, (_, { remaining, conformant }) => {
+                assert.equal(remaining, 8);
+                assert.ok(conformant)
+                cb();
+              }),
+
+              // call 3 - redis
+              // takes 4 tokens here, 2 for current call and 2 for previously skipped call
+              (cb) => testParams.take(params, (_, { remaining, conformant }) => {
+                assert.equal(remaining, 4);
+                assert.ok(conformant)
+                cb();
+              }),
+            ], (err, _results) => {
+              if (err) {
+                return done(err);
+              }
+              done();
+            })
+          });
+        })
+      })
+    })
 
     it('should use size config override when provided', (done) => {
       const configOverride = { size : 7 };
-      db.take({ type: 'ip', key: '7.7.7.7', configOverride}, (err, response) => {
+      db.take({type: 'ip', key: '7.7.7.7', configOverride}, (err, response) => {
         if (err) {
           return done(err);
         }
@@ -459,7 +679,7 @@ describe('LimitDBRedis', () => {
     it('should use per interval config override when provided', (done) => {
       const oneDayInMs = ms('24h');
       const configOverride = { per_day: 1 };
-      db.take({ type: 'ip', key: '7.7.7.8', configOverride}, (err, response) => {
+      db.take({type: 'ip', key: '7.7.7.8', configOverride}, (err, response) => {
         if (err) {
           return done(err);
         }
@@ -472,7 +692,7 @@ describe('LimitDBRedis', () => {
     it('should use size AND interval config override when provided', (done) => {
       const oneDayInMs = ms('24h');
       const configOverride = { size: 3, per_day: 1 };
-      db.take({ type: 'ip', key: '7.7.7.8', configOverride}, (err, response) => {
+      db.take({type: 'ip', key: '7.7.7.8', configOverride}, (err, response) => {
         if (err) {
           return done(err);
         }
@@ -488,7 +708,7 @@ describe('LimitDBRedis', () => {
 
     it('should set ttl to reflect config override', (done) => {
       const configOverride = { per_day: 5 };
-      const params = { type: 'ip', key: '7.7.7.9', configOverride};
+      const params = {type: 'ip', key: '7.7.7.9', configOverride};
       db.take(params, (err) => {
         if (err) {
           return done(err);
@@ -504,7 +724,7 @@ describe('LimitDBRedis', () => {
     });
 
     it('should work with no overrides', (done) => {
-      const takeParams = { type: 'tenant', key: 'foo'};
+      const takeParams = {type: 'tenant', key: 'foo'};
       db.take(takeParams, (err, response) => {
         assert.ok(response.conformant);
         assert.equal(response.remaining, 0);
@@ -522,7 +742,7 @@ describe('LimitDBRedis', () => {
       }
       db.configurateBuckets(big);
 
-      const takeParams = { type: 'ip', key: '172.16.1.1'};
+      const takeParams = {type: 'ip', key: '172.16.1.1'};
       async.map(_.range(10), (i, done) => {
         db.take(takeParams, done);
       }, (err, responses) => {
@@ -536,146 +756,16 @@ describe('LimitDBRedis', () => {
       });
     });
 
-    it('should call redis and not set local cache count', (done) => {
-      const params = { type: 'global',  key: 'aTenant'};
-      db.take(params, (err) => {
-        if (err) {
-          return done(err);
-        }
-
-        assert.equal(db.callCounts['global:aTenant'], undefined);
-        done();
-      });
-    });
-
-    describe('skip calls', () => {
-      it('should skip calls', (done) => {
-        const params = { type: 'global',  key: 'skipit'};
-
-        async.series([
-          (cb) => db.take(params, cb), // redis
-          (cb) => db.take(params, cb), // cache
-          (cb) => db.take(params, cb), // cache
-          (cb) => {
-            assert.equal(db.callCounts.get('global:skipit').count, 2);
-            cb();
-          },
-          (cb) => db.take(params, cb), // redis
-          (cb) => db.take(params, cb), // cache
-          (cb) => db.take(params, cb), // cache
-          (cb) => db.take(params, cb), // redis (first nonconformant)
-          (cb) => db.take(params, cb), // cache (first cached)
-          (cb) => {
-            assert.equal(db.callCounts.get('global:skipit').count, 1);
-            assert.notOk(db.callCounts.get('global:skipit').res.conformant);
-            cb();
-          },
-        ], (err, _results) => {
-          if (err) {
-            return done(err);
-          }
-
-          done();
-        })
-      });
-
-      it('should take correct number of tokens for skipped calls with single count', (done) => {
-        const params = { type: 'global',  key: 'skipOneSize3'};
-
-        // size = 3
-        // skip_n_calls = 1
-        // no refill
-        async.series([
-          (cb) => db.get(params, (_, {remaining}) => { assert.equal(remaining, 3); cb(); }),
-
-          // call 1 - redis
-          // takes 1 token
-          (cb) => db.take(params, (_, { remaining, conformant }) => {
-            assert.equal(remaining, 2);
-            assert.ok(conformant)
-            cb();
-          }),
-
-          // call 2 - skipped
-          (cb) => db.take(params, (_, { remaining, conformant }) => {
-            assert.equal(remaining, 2);
-            assert.ok(conformant)
-            cb();
-          }),
-
-          // call 3 - redis
-          // takes 2 tokens here, 1 for current call and one for previously skipped call
-          (cb) => db.take(params, (_, { remaining, conformant }) => {
-            assert.equal(remaining, 0);
-            assert.ok(conformant)
-            cb();
-          }),
-
-          // call 4 - skipped
-          // Note: this is the margin of error introduced by skip_n_calls. Without skip_n_calls, this call would be
-          // non-conformant.
-          (cb) => db.take(params, (_, { remaining, conformant }) => {
-            assert.equal(remaining, 0);
-            assert.ok(conformant);
-            cb();
-          }),
-
-          // call 5 - redis
-          (cb) => db.take(params, (_, { remaining, conformant }) => {
-            assert.equal(remaining, 0);
-            assert.notOk(conformant);
-            cb();
-          }),
-        ], (err, _results) => {
-          if (err) {
-            return done(err);
-          }
-          done();
-        })
-      });
-
-      it('should take correct number of tokens for skipped calls with multi count', (done) => {
-        const params = { type: 'global',  key: 'skipOneSize10', count: 2};
-
-        // size = 10
-        // skip_n_calls = 1
-        // no refill
-        async.series([
-          (cb) => db.get(params, (_, {remaining}) => { assert.equal(remaining, 10); cb(); }),
-
-          // call 1 - redis
-          // takes 2 tokens
-          (cb) => db.take(params, (_, { remaining, conformant }) => {
-            assert.equal(remaining, 8);
-            assert.ok(conformant)
-            cb();
-          }),
-
-          // call 2 - skipped
-          (cb) => db.take(params, (_, { remaining, conformant }) => {
-            assert.equal(remaining, 8);
-            assert.ok(conformant)
-            cb();
-          }),
-
-          // call 3 - redis
-          // takes 4 tokens here, 2 for current call and 2 for previously skipped call
-          (cb) => db.take(params, (_, { remaining, conformant }) => {
-            assert.equal(remaining, 4);
-            assert.ok(conformant)
-            cb();
-          }),
-        ], (err, _results) => {
-          if (err) {
-            return done(err);
-          }
-          done();
-        })
-      });
-    })
-
-    describe('elevated limits', () => {
+    describe('elevated limits specific tests', () => {
       const takeElevatedPromise = (params) => new Promise((resolve, reject) => {
+        db.takeElevated(params, (err, response) => {
+          if (err) {
+            return reject(err);
+          }
+          resolve(response);
+        });
+      });
+      const takePromise = (params) => new Promise((resolve, reject) => {
         db.take(params, (err, response) => {
           if (err) {
             return reject(err);
@@ -691,284 +781,304 @@ describe('LimitDBRedis', () => {
           resolve(isActive);
         });
       })
-      describe('when allowERL is true', () => {
-        it('should set a key at erlIsActiveKey when erl is activated for a bucket with elevated_limits configuration', async () => {
-          const bucketName = 'bucket_with_elevated_limits_config';
-          const erlIsActiveKey = 'some_erl_active_identifier';
-          db.configurateBucket(bucketName, {
-            size: 1,
-            per_minute: 1,
-            elevated_limits: {
-              size: 2,
-              per_minute: 2,
-            },
-          })
-          const params ={type: bucketName, key: 'some_key', erlIsActiveKey:erlIsActiveKey, allowERL:true}
-
-          // erl not activated yet
-          await takeElevatedPromise(params)
-          await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 0))
-
-          // erl now activated
-          await takeElevatedPromise(params)
-          await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 1))
-        });
-        it('should raise an error if erlIsActiveKey is not provided for a bucket with elevated_limits configuration', (done) => {
-          const bucketName = 'bucket_with_elevated_limits_config';
-          const params = {type: bucketName, key: 'some_bucket_key', erlIsActiveKey: undefined, allowERL:true};
-          db.configurateBucket(bucketName, {
-            size: 1,
-            per_minute: 1,
-            elevated_limits: {
-              size: 2,
-              per_minute: 2,
-            },
-          })
-
-          db.take(params, (err) => {
-            assert.match(err.message, /erlIsActiveKey is required for elevated limits/);
-            done();
-          });
-        });
-        it('should rate limit according to default configuration if there is no erl configuration, regardless of erlIsActiveKey', async () => {
-          const bucketName = 'bucket_without_erl_config';
-          db.configurateBucket(bucketName, {
+      it('should set a key at erlIsActiveKey when erl is activated for a bucket with elevated_limits configuration', async () => {
+        const bucketName = 'bucket_with_elevated_limits_config';
+        const erlIsActiveKey = 'some_erl_active_identifier';
+        db.configurateBucket(bucketName, {
+          size: 1,
+          per_minute: 1,
+          elevated_limits: {
             size: 2,
-            per_minute: 1,
-          })
-
-          await takeElevatedPromise({
-            type: bucketName,
-            key: 'some_bucket_key',
-            erlIsActiveKey: "some-key",
-            allowERL: true
-          }).then((result) => {
-            assert.isTrue(result.conformant);
-            assert.notExists(result.erl_activated);
-          });
-          await takeElevatedPromise({
-            type: bucketName,
-            key: 'some_bucket_key',
-            erlIsActiveKey: undefined
-          }).then((result) => {
-            assert.isTrue(result.conformant);
-            assert.notExists(result.erl_activated);
-          });
-        });
-        it('should apply erl limits if normal rate limits are exceeded', async () => {
-          const bucketName = 'bucket_with_elevated_limits_config';
-          db.configurateBucket(bucketName, {
-            size: 1,
-            per_minute: 1,
-            elevated_limits: {
-              size: 10,
-              per_minute: 2,
-            },
-          })
-          const params = {
-            type: bucketName,
-            key: 'some_bucket_key',
-            erlIsActiveKey: 'some_erl_active_identifier',
-            allowERL: true,
-          }
-
-          // first call, still within normal rate limits
-          await takeElevatedPromise(params).then((result) => {
-            assert.isFalse(result.erl_activated);
-          })
-          // second call, normal rate limits exceeded and erl is activated
-          await takeElevatedPromise(params).then((result) => {
-            assert.isTrue(result.erl_activated);
-            assert.isTrue(result.conformant);
-            assert.equal(result.remaining, 8)
-          })
-
-        });
-        it('should rate limit if both normal and erl rate limit are exceeded', async () => {
-          const bucketName = 'bucket_with_elevated_limits_config';
-          const params = {type: bucketName, key: 'some_bucket_key', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true,}
-          db.configurateBucket(bucketName, {
-            size: 1,
-            per_minute: 1,
-            elevated_limits: {
-              size: 2,
-              per_minute: 2,
-            },
-          })
-
-          // first call, still within normal rate limits
-          await takeElevatedPromise(params).then((result) => {
-            assert.isTrue(result.conformant);
-            assert.isFalse(result.erl_activated);
-            assert.equal(result.remaining, 0)
-          })
-          // second call, normal rate limits exceeded and erl is activated.
-          // tokens in bucket is going to be 0 after this call (size 2 - 2 calls)
-          await takeElevatedPromise(params).then((result) => {
-            assert.isTrue(result.conformant);
-            assert.isTrue(result.erl_activated);
-            assert.equal(result.remaining, 0);
-          })
-          // third call, erl rate limit exceeded
-          await takeElevatedPromise(params).then((result) => {
-            assert.isFalse(result.conformant); // being rate limited
-            assert.isTrue(result.erl_activated);
-            assert.equal(result.remaining, 0);
-          })
-        });
-        it('should deduct already used tokens from new bucket when erl is activated', async () => {
-          const bucketName = 'test-bucket';
-          const params = {type: bucketName, key: 'some_key ', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true}
-          await db.configurateBucket(bucketName, {
-            size: 2,
-            per_minute: 1,
-            elevated_limits: {
-              size: 10,
-              per_minute: 1,
-            }
-          });
-
-          await takeElevatedPromise(params)
-          await takeElevatedPromise(params)
-          await takeElevatedPromise(params).then((result) => {
-            assert.isTrue(result.conformant);
-            assert.isTrue(result.erl_activated);
-            assert.equal(result.remaining, 7); // Total used tokens so far: 3
-          });
+            per_minute: 2,
+          },
         })
-        it('should use default ttl if erl activation period is not configured', (done) => {
-          const bucketName = 'test-bucket';
-          const params = {type: bucketName, key: 'some_key', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true};
-          db.configurateBucket(bucketName, {
-            size: 1,
-            per_minute: 1,
-            elevated_limits: {
-              size: 10,
-              per_minute: 1,
-            }
-          });
-          takeElevatedPromise(params)
-              .then(() => takeElevatedPromise(params))
-              .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
-                assert.equal(ttl, ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS); // 15 minutes in seconds
-                done()
-              }))
-        });
-        it('should use ttl calculated using erl activation period if erl activation period is configured', (done) => {
-          const bucketName = 'test-bucket';
-          const params = {type: bucketName, key: 'some_key', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true};
-          db.configurateBucket(bucketName, {
-            size: 1,
-            per_minute: 1,
-            elevated_limits: {
-              size: 10,
-              per_minute: 1,
-              erl_activation_period_seconds: 1200,
-            }
-          });
-          takeElevatedPromise(params)
-              .then(() => takeElevatedPromise(params))
-              .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
-                assert.equal(ttl, 1200); // 20 minutes in seconds
-                done()
-              }))
-        });
-        it('should refill with erl refill rate when erl is active', (done) => {
-          const bucketName = 'test-bucket';
-          const params = {type: bucketName, key: 'some_key ', erlIsActiveKey: 'some_erl_active_identifier', allowERL:true};
-          db.configurateBucket(bucketName, {
-            size: 1,
-            per_minute: 1,
-            elevated_limits: {
-              size: 5,
-              per_interval: 1,
-              interval: 10,
-            }
-          });
-          takeElevatedPromise(params)
-              .then(() => takeElevatedPromise(params)) // erl activated
-              .then(() => new Promise((resolve) => setTimeout(resolve, 10))) // wait for 10ms
-              .then(() => takeElevatedPromise(params)) // refill with erl refill rate
-              .then((result) => {
-                assert.isTrue(result.conformant);
-                assert.isTrue(result.erl_activated);
-                assert.equal(result.remaining, 3);
-                done();
-              })
-        });
-        it('should go back to standard bucket size and refill rate if allowERL is turned into false', (done) => {
-          const bucketName = 'test-bucket';
-          const params = {type: bucketName, key:  'some_key', erlIsActiveKey: 'some_erl_active_identifier', allowERL:true};
-          db.configurateBucket(bucketName, {
-              size: 1,
-              per_interval: 1,
-              interval: 2,
-              elevated_limits: {
-                  size: 5,
-                  per_interval: 1,
-                  interval: 5,
-              }
-          });
+        const params ={type: bucketName, key: 'some_key', erlIsActiveKey:erlIsActiveKey, allowERL:true}
 
-          // first call to take a token
-          takeElevatedPromise(params)
-              // second call. erl activated and token taken. tokens in bucket: 3
-              .then(() => takeElevatedPromise(params))
-              // wait for 5ms, refill 1 token while erl active. tokens in bucket: 4
-              .then(() => new Promise((resolve) => setTimeout(resolve, 5)))
-              // take 1 token. tokens in bucket: 3
-              .then(() => takeElevatedPromise(params))
-              .then((result) => {
-                assert.isTrue(result.conformant);
-                assert.isTrue(result.erl_activated);
-                assert.equal(result.remaining, 3);
-              })
-              // disable ERL, go back to standard bucket size and refill rate
-              // tokens in bucket: 1 (= bucket size)
-              // take 1 token. tokens in bucket: 0
-              .then(() => takeElevatedPromise({...params, allowERL:false}))
-              .then((result) => {
-                  assert.isTrue(result.conformant);
-                  assert.notExists(result.erl_activated);
-                  assert.equal(result.remaining, 0);
-              })
-              // wait for 2ms, refill 1 token while erl inactive. tokens in bucket: 1
-              .then(() => new Promise((resolve) => setTimeout(resolve, 2)))
-              // take 1 token. tokens in bucket: 0
-              .then(() => takeElevatedPromise({...params, allowERL:false}))
-              .then((result) => {
+        // erl not activated yet
+        await takeElevatedPromise(params)
+        await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 0))
+
+        // erl now activated
+        await takeElevatedPromise(params)
+        await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 1))
+      });
+      it('should raise an error if erlIsActiveKey is not provided for a bucket with elevated_limits configuration', (done) => {
+        const bucketName = 'bucket_with_elevated_limits_config';
+        const params = {type: bucketName, key: 'some_bucket_key', erlIsActiveKey: undefined, allowERL:true};
+        db.configurateBucket(bucketName, {
+          size: 1,
+          per_minute: 1,
+          elevated_limits: {
+            size: 2,
+            per_minute: 2,
+          },
+        })
+
+        db.takeElevated(params, (err) => {
+          assert.match(err.message, /erlIsActiveKey is required for elevated limits/);
+          done();
+        });
+      });
+      it('should apply erl limits if normal rate limits are exceeded', async () => {
+        const bucketName = 'bucket_with_elevated_limits_config';
+        db.configurateBucket(bucketName, {
+          size: 1,
+          per_minute: 1,
+          elevated_limits: {
+            size: 10,
+            per_minute: 2,
+          },
+        })
+        const params = {
+          type: bucketName,
+          key: 'some_bucket_key',
+          erlIsActiveKey: 'some_erl_active_identifier',
+          allowERL: true,
+        }
+
+        // first call, still within normal rate limits
+        await takeElevatedPromise(params).then((result) => {
+          assert.isFalse(result.erl_activated);
+        })
+        // second call, normal rate limits exceeded and erl is activated
+        await takeElevatedPromise(params).then((result) => {
+          assert.isTrue(result.erl_activated);
+          assert.isTrue(result.conformant);
+          assert.equal(result.remaining, 8)
+        })
+
+      });
+      it('should rate limit if both normal and erl rate limit are exceeded', async () => {
+        const bucketName = 'bucket_with_elevated_limits_config';
+        const params = {type: bucketName, key: 'some_bucket_key', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true,}
+        db.configurateBucket(bucketName, {
+          size: 1,
+          per_minute: 1,
+          elevated_limits: {
+            size: 2,
+            per_minute: 2,
+          },
+        })
+
+        // first call, still within normal rate limits
+        await takeElevatedPromise(params).then((result) => {
+          assert.isTrue(result.conformant);
+          assert.isFalse(result.erl_activated);
+          assert.equal(result.remaining, 0)
+        })
+        // second call, normal rate limits exceeded and erl is activated.
+        // tokens in bucket is going to be 0 after this call (size 2 - 2 calls)
+        await takeElevatedPromise(params).then((result) => {
+          assert.isTrue(result.conformant);
+          assert.isTrue(result.erl_activated);
+          assert.equal(result.remaining, 0);
+        })
+        // third call, erl rate limit exceeded
+        await takeElevatedPromise(params).then((result) => {
+          assert.isFalse(result.conformant); // being rate limited
+          assert.isTrue(result.erl_activated);
+          assert.equal(result.remaining, 0);
+        })
+      });
+      it('should deduct already used tokens from new bucket when erl is activated', async () => {
+        const bucketName = 'test-bucket';
+        const params = {type: bucketName, key: 'some_key ', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true}
+        await db.configurateBucket(bucketName, {
+          size: 2,
+          per_minute: 1,
+          elevated_limits: {
+            size: 10,
+            per_minute: 1,
+          }
+        });
+
+        await takeElevatedPromise(params)
+        await takeElevatedPromise(params)
+        await takeElevatedPromise(params).then((result) => {
+          assert.isTrue(result.conformant);
+          assert.isTrue(result.erl_activated);
+          assert.equal(result.remaining, 7); // Total used tokens so far: 3
+        });
+      })
+      it('should use default ttl if erl activation period is not configured', (done) => {
+        const bucketName = 'test-bucket';
+        const params = {type: bucketName, key: 'some_key', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true};
+        db.configurateBucket(bucketName, {
+          size: 1,
+          per_minute: 1,
+          elevated_limits: {
+            size: 10,
+            per_minute: 1,
+          }
+        });
+        takeElevatedPromise(params)
+            .then(() => takeElevatedPromise(params))
+            .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
+              assert.equal(ttl, ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS); // 15 minutes in seconds
+              done()
+            }))
+      });
+      it('should use ttl calculated using erl activation period if erl activation period is configured', (done) => {
+        const bucketName = 'test-bucket';
+        const params = {type: bucketName, key: 'some_key', erlIsActiveKey: 'some_erl_active_identifier', allowERL: true};
+        db.configurateBucket(bucketName, {
+          size: 1,
+          per_minute: 1,
+          elevated_limits: {
+            size: 10,
+            per_minute: 1,
+            erl_activation_period_seconds: 1200,
+          }
+        });
+        takeElevatedPromise(params)
+            .then(() => takeElevatedPromise(params))
+            .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
+              assert.equal(ttl, 1200); // 20 minutes in seconds
+              done()
+            }))
+      });
+      it('should refill with erl refill rate when erl is active', (done) => {
+        const bucketName = 'test-bucket';
+        const params = {type: bucketName, key: 'some_key ', erlIsActiveKey: 'some_erl_active_identifier', allowERL:true};
+        db.configurateBucket(bucketName, {
+          size: 1,
+          per_minute: 1,
+          elevated_limits: {
+            size: 5,
+            per_interval: 1,
+            interval: 10,
+          }
+        });
+        takeElevatedPromise(params)
+            .then(() => takeElevatedPromise(params)) // erl activated
+            .then(() => new Promise((resolve) => setTimeout(resolve, 10))) // wait for 10ms
+            .then(() => takeElevatedPromise(params)) // refill with erl refill rate
+            .then((result) => {
+              assert.isTrue(result.conformant);
+              assert.isTrue(result.erl_activated);
+              assert.equal(result.remaining, 3);
+              done();
+            })
+      });
+      it('should go back to standard bucket size and refill rate when we stop using takeElevated', (done) => {
+        const bucketName = 'test-bucket';
+        const params = {type: bucketName, key:  'some_key', erlIsActiveKey: 'some_erl_active_identifier', allowERL:true};
+        db.configurateBucket(bucketName, {
+            size: 1,
+            per_interval: 1,
+            interval: 2,
+            elevated_limits: {
+                size: 5,
+                per_interval: 1,
+                interval: 5,
+            }
+        });
+
+        // first call to take a token
+        takeElevatedPromise(params)
+            // second call. erl activated and token taken. tokens in bucket: 3
+            .then(() => takeElevatedPromise(params))
+            // wait for 5ms, refill 1 token while erl active. tokens in bucket: 4
+            .then(() => new Promise((resolve) => setTimeout(resolve, 5)))
+            // take 1 token. tokens in bucket: 3
+            .then(() => takeElevatedPromise(params))
+            .then((result) => {
+              assert.isTrue(result.conformant);
+              assert.isTrue(result.erl_activated);
+              assert.equal(result.remaining, 3);
+            })
+            // disable ERL, go back to standard bucket size and refill rate
+            // tokens in bucket: 1 (= bucket size)
+            // take 1 token. tokens in bucket: 0
+            .then(() => takePromise(params))
+            .then((result) => {
                 assert.isTrue(result.conformant);
                 assert.notExists(result.erl_activated);
                 assert.equal(result.remaining, 0);
-                done();
-              })
-        });
+            })
+            // wait for 2ms, refill 1 token while erl inactive. tokens in bucket: 1
+            .then(() => new Promise((resolve) => setTimeout(resolve, 2)))
+            // take 1 token. tokens in bucket: 0
+            .then(() => takePromise(params))
+            .then((result) => {
+              assert.isTrue(result.conformant);
+              assert.notExists(result.erl_activated);
+              assert.equal(result.remaining, 0);
+              done();
+            })
       });
-      describe('when allowERL is false', () => {
-        it('should use normal rate limits regardless of erl configuration or erlIsActiveKey', async () => {
-          const bucketName = 'bucket_with_elevated_limits_config';
+
+      it('should return an error when attempting to takeElevated with no elevate config', (done) => {
+        const bucketName = 'bucket_with_no_elevated_limits_config';
+        const erlIsActiveKey = 'some_erl_active_identifier';
+        db.configurateBucket(bucketName, {
+          size: 1,
+          per_minute: 1
+        })
+        const params = {type: bucketName, key: 'some_key', erlIsActiveKey:erlIsActiveKey, allowERL:true}
+        db.takeElevated(params, (err) => {
+          assert.match(err.message, /Attempted to takeElevated\(\) for a bucket with no elevated config/);
+          done();
+        });
+      })
+
+      describe('overrides', () => {
+        it('should use elevated_limits config override when provided', (done) => {
+          const bucketName = 'bucket_with_no_elevated_limits_config';
+          const erlIsActiveKey = 'some_erl_active_identifier';
+          db.configurateBucket(bucketName, {
+            size: 1,
+            per_minute: 1
+          })
+          const configOverride = { size: 1, elevated_limits: {size: 3, per_second: 3} };
+          const params = {type: bucketName, key: 'some_key', erlIsActiveKey: erlIsActiveKey, configOverride}
+          takeElevatedPromise(params)
+            .then((result) => {
+              assert.isTrue(result.conformant)
+              assert.isFalse(result.erl_activated)
+            })
+            .then(() => takeElevatedPromise(params))
+            .then(() => takeElevatedPromise(params))
+            .then((result) => {
+              assert.isTrue(result.conformant)
+              assert.isTrue(result.erl_activated)
+              assert.equal(result.remaining, 0)
+            })
+            .then(() => takeElevatedPromise(params))
+            .then((result) => {
+              assert.isFalse(result.conformant)
+              db.redis.ttl(erlIsActiveKey, (err, ttl) => {
+                assert.equal(ttl, ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS); // uses default activation period
+                done()
+              })
+            })
+        });
+        it('should use erl_activation_period from elevated_limits config override when provided', (done) => {
+          const bucketName = 'bucket_with_no_elevated_limits_config';
           const erlIsActiveKey = 'some_erl_active_identifier';
           db.configurateBucket(bucketName, {
             size: 1,
             per_minute: 1,
-            elevated_limits: {
-              size: 2,
-              per_minute: 2,
-            },
+            erl_activation_period_seconds: 900
           })
-          const params ={type: bucketName, key: 'some_key', erlIsActiveKey:erlIsActiveKey, allowERL:false}
-
-          // erl not activated yet
-          await takeElevatedPromise(params)
-
-          // erl is supposed to be activated, but will not be
-          await takeElevatedPromise(params).then((result) => {
-            assert.isFalse(result.conformant);
-            assert.notExists(result.erl_activated);
-          });
-          await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 0))
+          const configOverride = { size: 1, elevated_limits: {size: 3, per_second: 3, erl_activation_period_seconds: 60} };
+          const params = {type: bucketName, key: 'some_key', erlIsActiveKey: erlIsActiveKey, configOverride}
+          takeElevatedPromise(params)
+            .then((result) => {
+              assert.isTrue(result.conformant)
+              assert.isFalse(result.erl_activated)
+            })
+            .then(() => takeElevatedPromise(params))
+            .then((result) => {
+              assert.isTrue(result.conformant)
+              assert.isTrue(result.erl_activated)
+              db.redis.ttl(erlIsActiveKey, (err, ttl) => {
+                assert.equal(ttl, 60); // uses specified activation period
+                done()
+              })
+            })
         });
-      });
+      })
     });
   });
 


### PR DESCRIPTION
### Description

This PR implements the core mechanism for a new rate limits capability called Elevated Rate Limits (ERL).

### **What is ERL?**
ERL is a feature that will allow defining a different set of limits that temporarily kick in when the bucket is empty. The feature aims to provide a way to temporarily allow a higher rate of requests when the bucket is empty, to reduce friction.
In its final form, the feature will allow setting a quota for how long and how many times ERL can be activated for a given bucket - however, this quota counting ability is out of the scope of this PR.

Please see changes to README for details on what needs to be provided to enable and use ERL.

### **Is the change backwards-compatible?**
Yes. You don't have to make any changes to your existing usages.

If a bucket has ERL configured, and `limitd.takeElevated` is called:
-- Whenever the bucket runs out of tokens, ERL is activated.
-- ERL stays active until erl_activation_period_mins is expired, then the normal bucket configuration takes effect again.

Out of scope of this PR, but upcoming:
 - Quota for ERL activation.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
