### PR TITLE
feat:ERL quota counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ The feature aims to provide a way to temporarily allow a higher rate of requests
 
 To be able to allow its use within limitd-redis, you need to:
 1. call the `takeElevated` method.
-2. pass the `elevatedLimits` parameter with the following properties:
-   - `erlIsActiveKey`: the identifier of the ERL activation for the bucket. This works similarly to the `key` you pass to `limitd.take`, which is the identifier of the bucket; however it's used to track the ERL activation for the bucket instead
-   - `erlQuotaKey`: the identifier of the ERL quota bucket name.
+2. pass the `elevated_limits` parameter with the following properties:
+   - `erl_is_active_key`: the identifier of the ERL activation for the bucket. This works similarly to the `key` you pass to `limitd.take`, which is the identifier of the bucket; however it's used to track the ERL activation for the bucket instead
+   - `erl_quota_key`: the identifier of the ERL quota bucket name.
    - `per_calendar_month`: the amount of tokens that the quota bucket will receive on every calendar month.
 3. make sure that the bucket definition has ERL configured.
 
@@ -143,7 +143,7 @@ buckets = {
 ```
 
 ### ERL Quota
-ERL quota represents the number of ERL activations that can be performed in a calendar month for the given `erlQuotaKey`.
+ERL quota represents the number of ERL activations that can be performed in a calendar month for the given `erl_quota_key`.
 
 When ERL is triggered, it will keep activated for the `erl_activation_period_seconds` defined in the bucket configuration.
 
@@ -182,7 +182,7 @@ The result object has:
 This take operation allows the use of elevated rate limits if it corresponds.
 
 ```js
-limitd.takeElevated(type, key, { count, configOverride, elevatedLimits }, (err, result) => {
+limitd.takeElevated(type, key, { count, configOverride, elevated_limits }, (err, result) => {
   console.log(result);
 });
 ```
@@ -193,9 +193,9 @@ limitd.takeElevated(type, key, { count, configOverride, elevatedLimits }, (err, 
 -  `key`: the identifier of the bucket.
 -  `count`: the amount of tokens you need. This is optional and the default is 1.
 -  `configOverride`: caller-provided bucket configuration for this operation
--  `elevatedLimits`: (object)
-  - `erlIsActiveKey`: (string) the identifier of the ERL activation for the bucket.
-  - `erlQuotaKey`: (string) the identifier of the ERL quota bucket name.
+-  `elevated_limits`: (object)
+  - `erl_is_active_key`: (string) the identifier of the ERL activation for the bucket.
+  - `erl_quota_key`: (string) the identifier of the ERL quota bucket name.
   - `per_calendar_month`: (number) the amount of tokens that the quota bucket will receive on every calendar month.
 
 `erlQuota.per_calendar_month` is the only refill rate available for ERL quota buckets at the moment. 
@@ -215,7 +215,7 @@ The result object has:
 -  `elevated_limits` (object)
   -  `triggered` (boolean): true if ERL was triggered in the current request.
   -  `activated` (boolean): true if ERL is activated. Not necessarily triggered in this call.
-  -  `quota_count` (int): **[Only valid if triggered=true]** If `triggered=true`, this value contains the current quota count for the given `erlQuotaKey`. Otherwise, it will return -1, which is not valid to be interpreted as a quota count.
+  -  `quota_count` (int): **[Only valid if triggered=true]** If `triggered=true`, this value contains the current quota count for the given `erl_quota_key`. Otherwise, it will return -1, which is not valid to be interpreted as a quota count.
 
 Example of interpretation:
 ``` javascript

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ The result object has:
 This take operation allows the use of elevated rate limits if it corresponds.
 
 ```js
-limitd.takeElevated(type, key, { count, configOverride, erlIsActive }, (err, result) => {
+limitd.takeElevated(type, key, { count, configOverride, erlIsActive, erlQuota }, (err, result) => {
   console.log(result);
 });
 ```
@@ -182,6 +182,19 @@ limitd.takeElevated(type, key, { count, configOverride, erlIsActive }, (err, res
 -  `count`: the amount of tokens you need. This is optional and the default is 1.
 -  `configOverride`: caller-provided bucket configuration for this operation
 -  `erlIsActiveKey`: (string) the identifier of the ERL activation for the bucket.
+-  `erlQuota`: (object)
+  - `key`: (string) the identifier of the ERL quota bucket name.
+  - `per_cal_month`: (number) the amount of tokens that the quota bucket will receive on every calendar month.
+
+`erlQuota.per_cal_month` is the only refill rate available for ERL quota buckets at the moment. 
+The quota bucket will be used to track the amount of ERL activations that can be done in a calendar month. 
+If the quota bucket is empty, the ERL activation will not be possible. 
+The quota bucket will be refilled at the beginning of every calendar month.
+
+For instance, if you want to allow a user to activate ERL for a bucket only 5 times in a month, you can define a quota bucket with `per_cal_month: 5`.
+That means that the user can activate ERL for the bucket 5 times in a month, and after that, the ERL activation will not be possible until the start of the next month.
+
+The total minutes allowed for ERL activation in a calendar month is calculated as follows: `per_cal_month * erl_activation_period_seconds`. 
 
 The result object has:
 -  `conformant` (boolean): true if the requested amount is conformant to the limit.
@@ -189,6 +202,7 @@ The result object has:
 -  `reset` (int / unix timestamp): unix timestamp of the date when the bucket will be full again.
 -  `limit` (int): the size of the bucket.
 -  `erl_activated` (boolean): true if the bucket has ERL activated at the time of the request. Only returned for buckets that have ERL configured.
+-  `erl_quota_count` (int): If erl was activated in the current request, this value contains the current quota count. Otherwise, -1 is returned.
 
 ## PUT
 

--- a/README.md
+++ b/README.md
@@ -181,9 +181,9 @@ limitd.takeElevated(type, key, { count, configOverride, erlIsActive, erlQuota },
 -  `key`: the identifier of the bucket.
 -  `count`: the amount of tokens you need. This is optional and the default is 1.
 -  `configOverride`: caller-provided bucket configuration for this operation
--  `erlIsActiveKey`: (string) the identifier of the ERL activation for the bucket.
--  `erlQuota`: (object)
-  - `key`: (string) the identifier of the ERL quota bucket name.
+-  `elevatedLimits`: (object)
+  - `erlIsActiveKey`: (string) the identifier of the ERL activation for the bucket.
+  - `erlQuotaKey`: (string) the identifier of the ERL quota bucket name.
   - `per_calendar_month`: (number) the amount of tokens that the quota bucket will receive on every calendar month.
 
 `erlQuota.per_calendar_month` is the only refill rate available for ERL quota buckets at the moment. 

--- a/README.md
+++ b/README.md
@@ -184,16 +184,16 @@ limitd.takeElevated(type, key, { count, configOverride, erlIsActive, erlQuota },
 -  `erlIsActiveKey`: (string) the identifier of the ERL activation for the bucket.
 -  `erlQuota`: (object)
   - `key`: (string) the identifier of the ERL quota bucket name.
-  - `per_cal_month`: (number) the amount of tokens that the quota bucket will receive on every calendar month.
+  - `per_calendar_month`: (number) the amount of tokens that the quota bucket will receive on every calendar month.
 
-`erlQuota.per_cal_month` is the only refill rate available for ERL quota buckets at the moment. 
+`erlQuota.per_calendar_month` is the only refill rate available for ERL quota buckets at the moment. 
 The quota bucket will be used to track the amount of ERL activations that can be done in a calendar month. 
 If the quota bucket is empty, the ERL activation will not be possible. 
 The quota bucket will be refilled at the beginning of every calendar month.
 
-For instance, if you want to allow a user to activate ERL for a bucket only 5 times in a month, you can define a quota bucket with `per_cal_month: 5`.
+For instance, if you want to allow a user to activate ERL for a bucket only 5 times in a month, you can define a quota bucket with `per_calendar_month: 5`.
 That means that the user can activate ERL for the bucket 5 times in a month, and after that, the ERL activation will not be possible until the start of the next month.
-The total minutes allowed for ERL activation in a calendar month is calculated as follows: `per_cal_month * erl_activation_period_seconds / 60`.
+The total minutes allowed for ERL activation in a calendar month is calculated as follows: `per_calendar_month * erl_activation_period_seconds / 60`.
 
 The result object has:
 -  `conformant` (boolean): true if the requested amount is conformant to the limit.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The result object has:
 -  `reset` (int / unix timestamp): unix timestamp of the date when the bucket will be full again.
 -  `limit` (int): the size of the bucket.
 -  `erl_activated` (boolean): true if the bucket has ERL activated at the time of the request. Only returned for buckets that have ERL configured.
--  `erl_quota_count` (int): If erl was activated in the current request, this value contains the current quota count. Otherwise, -1 is returned.
+-  `erl_quota_count` (int): If erl was activated in the current request, this value contains the current quota count, which is the number of times ERL can be activated. Otherwise, -1 is returned.
 
 ## PUT
 

--- a/README.md
+++ b/README.md
@@ -193,8 +193,7 @@ The quota bucket will be refilled at the beginning of every calendar month.
 
 For instance, if you want to allow a user to activate ERL for a bucket only 5 times in a month, you can define a quota bucket with `per_cal_month: 5`.
 That means that the user can activate ERL for the bucket 5 times in a month, and after that, the ERL activation will not be possible until the start of the next month.
-
-The total minutes allowed for ERL activation in a calendar month is calculated as follows: `per_cal_month * erl_activation_period_seconds`. 
+The total minutes allowed for ERL activation in a calendar month is calculated as follows: `per_cal_month * erl_activation_period_seconds / 60`.
 
 The result object has:
 -  `conformant` (boolean): true if the requested amount is conformant to the limit.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ overrides: {
 ```
 
 ## ERL (Elevated Rate Limits)
+### Prerequisites
+Redis 6.2+ is required to use ERL.
+
+### Introduction
 ERL is a feature that allows you to define a different set of limits that kick in when the bucket is empty.
 The feature aims to provide a way to temporarily allow a higher rate of requests when the bucket is empty, for a limited period of time.
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The result object has:
 This take operation allows the use of elevated rate limits if it corresponds.
 
 ```js
-limitd.takeElevated(type, key, { count, configOverride, erlIsActive, erlQuota }, (err, result) => {
+limitd.takeElevated(type, key, { count, configOverride, elevatedLimits }, (err, result) => {
   console.log(result);
 });
 ```

--- a/lib/db.js
+++ b/lib/db.js
@@ -93,7 +93,7 @@ class LimitDBRedis extends EventEmitter {
     });
 
     this.redis.defineCommand('takeElevated', {
-      numberOfKeys: 2,
+      numberOfKeys: 3,
       lua: TAKE_ELEVATED_LUA
     });
 
@@ -293,13 +293,14 @@ class LimitDBRedis extends EventEmitter {
     if (valError) {
       return callback(valError)
     }
+    const erlQuota = utils.extractERLQuota(params);
 
     this._doTake(params, callback, (key, bucketKeyConfig, count) => {
       const valError = validateConfigIsForElevatedBucket(key, bucketKeyConfig)
       if (valError) {
         return callback(valError)
       }
-      this.redis.takeElevated(key, params.erlIsActiveKey,
+      this.redis.takeElevated(key, params.erlIsActiveKey, erlQuota.key,
         bucketKeyConfig.ms_per_interval || 0,
         bucketKeyConfig.size,
         count,
@@ -308,6 +309,8 @@ class LimitDBRedis extends EventEmitter {
         bucketKeyConfig.elevated_limits.ms_per_interval || 0,
         bucketKeyConfig.elevated_limits.size,
         bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
+        erlQuota.amount,
+        erlQuota.expiration,
         (err, results) => {
           if (err) {
             return callback(err);

--- a/lib/db.js
+++ b/lib/db.js
@@ -289,18 +289,18 @@ class LimitDBRedis extends EventEmitter {
   }
 
   takeElevated(params, callback) {
-    const valError = validateERLParams(params);
+    const valError = validateERLParams(params.elevatedLimits);
     if (valError) {
       return callback(valError)
     }
-    const erlQuota = utils.getERLQuotaAmountAndExpiration(params);
+    const erlParams = utils.getERLKeysQuotaAmountAndExpiration(params.elevatedLimits);
 
     this._doTake(params, callback, (key, bucketKeyConfig, count) => {
       const valError = validateConfigIsForElevatedBucket(key, bucketKeyConfig)
       if (valError) {
         return callback(valError)
       }
-      this.redis.takeElevated(key, params.erlIsActiveKey, erlQuota.key,
+      this.redis.takeElevated(key, erlParams.erlIsActiveKey, erlParams.erlQuotaKey,
         bucketKeyConfig.ms_per_interval || 0,
         bucketKeyConfig.size,
         count,
@@ -309,8 +309,8 @@ class LimitDBRedis extends EventEmitter {
         bucketKeyConfig.elevated_limits.ms_per_interval || 0,
         bucketKeyConfig.elevated_limits.size,
         bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
-        erlQuota.amount,
-        erlQuota.expiration,
+        erlParams.amount,
+        erlParams.expiration,
         (err, results) => {
           if (err) {
             return callback(err);

--- a/lib/db.js
+++ b/lib/db.js
@@ -289,18 +289,18 @@ class LimitDBRedis extends EventEmitter {
   }
 
   takeElevated(params, callback) {
-    const valError = validateERLParams(params.elevatedLimits);
+    const valError = validateERLParams(params.elevated_limits);
     if (valError) {
       return callback(valError)
     }
-    const erlParams = utils.getERLKeysQuotaAmountAndExpiration(params.elevatedLimits);
+    const erlParams = utils.getERLKeysQuotaAmountAndExpiration(params.elevated_limits);
 
     this._doTake(params, callback, (key, bucketKeyConfig, count) => {
       const valError = validateConfigIsForElevatedBucket(key, bucketKeyConfig)
       if (valError) {
         return callback(valError)
       }
-      this.redis.takeElevated(key, erlParams.erlIsActiveKey, erlParams.erlQuotaKey,
+      this.redis.takeElevated(key, erlParams.erl_is_active_key, erlParams.erl_quota_key,
         bucketKeyConfig.ms_per_interval || 0,
         bucketKeyConfig.size,
         count,

--- a/lib/db.js
+++ b/lib/db.js
@@ -309,8 +309,8 @@ class LimitDBRedis extends EventEmitter {
         bucketKeyConfig.elevated_limits.ms_per_interval || 0,
         bucketKeyConfig.elevated_limits.size,
         bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
-        erlParams.amount,
-        erlParams.expiration,
+        erlParams.erl_quota_amount,
+        erlParams.erl_quota_expiration,
         (err, results) => {
           if (err) {
             return callback(err);

--- a/lib/db.js
+++ b/lib/db.js
@@ -319,16 +319,20 @@ class LimitDBRedis extends EventEmitter {
           const conformant = parseInt(results[1], 10) ? true : false;
           const currentMS = parseInt(results[2], 10);
           const reset = parseInt(results[3], 10);
-          const erl_activated = parseInt(results[4], 10) ? true : false;
-          const erl_quota_count = parseInt(results[5], 10);
+          const erl_triggered = parseInt(results[4], 10) ? true : false;
+          const erl_activated = parseInt(results[5], 10) ? true : false;
+          const erl_quota_count = parseInt(results[6], 10);
           const res = {
             conformant,
             remaining,
             reset: Math.ceil(reset / 1000),
             limit: bucketKeyConfig.size,
             delayed: false,
-            erl_activated,
-            erl_quota_count
+            elevated_limits : {
+              triggered: erl_triggered,
+              activated: erl_activated,
+              quota_count: erl_quota_count
+            },
           };
           if (bucketKeyConfig.skip_n_calls > 0) {
             this.callCounts.set(key, { res, count: 0 });

--- a/lib/db.js
+++ b/lib/db.js
@@ -293,7 +293,7 @@ class LimitDBRedis extends EventEmitter {
     if (valError) {
       return callback(valError)
     }
-    const erlQuota = utils.extractERLQuota(params);
+    const erlQuota = utils.getERLQuotaAmountAndExpiration(params);
 
     this._doTake(params, callback, (key, bucketKeyConfig, count) => {
       const valError = validateConfigIsForElevatedBucket(key, bucketKeyConfig)

--- a/lib/db.js
+++ b/lib/db.js
@@ -320,6 +320,7 @@ class LimitDBRedis extends EventEmitter {
           const currentMS = parseInt(results[2], 10);
           const reset = parseInt(results[3], 10);
           const erl_activated = parseInt(results[4], 10) ? true : false;
+          const erl_quota_count = parseInt(results[5], 10);
           const res = {
             conformant,
             remaining,
@@ -327,6 +328,7 @@ class LimitDBRedis extends EventEmitter {
             limit: bucketKeyConfig.size,
             delayed: false,
             erl_activated,
+            erl_quota_count
           };
           if (bucketKeyConfig.skip_n_calls > 0) {
             this.callCounts.set(key, { res, count: 0 });

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -74,7 +74,7 @@ end
 
 local enough_tokens = bucket_content_after_refill >= tokens_to_take
 local bucket_content_after_take = bucket_content_after_refill
-local erlQuota = 0
+local erlQuota = -1
 
 if enough_tokens then
     if is_erl_activated == 1 then

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -1,13 +1,13 @@
-local tokens_per_ms               = tonumber(ARGV[1])
-local bucket_size                 = tonumber(ARGV[2])
-local tokens_to_take              = tonumber(ARGV[3])
-local ttl                         = tonumber(ARGV[4])
-local drip_interval               = tonumber(ARGV[5])
-local erl_tokens_per_ms           = tonumber(ARGV[6])
-local erl_bucket_size             = tonumber(ARGV[7])
-local erl_activation_period_seconds  = tonumber(ARGV[8])
-local erl_quota_amount              = tonumber(ARGV[9])
-local erl_quota_expiration_epoch  = tonumber(ARGV[10])
+local tokens_per_ms = tonumber(ARGV[1])
+local bucket_size = tonumber(ARGV[2])
+local tokens_to_take = tonumber(ARGV[3])
+local ttl = tonumber(ARGV[4])
+local drip_interval = tonumber(ARGV[5])
+local erl_tokens_per_ms = tonumber(ARGV[6])
+local erl_bucket_size = tonumber(ARGV[7])
+local erl_activation_period_seconds = tonumber(ARGV[8])
+local erl_quota_amount = tonumber(ARGV[9])
+local erl_quota_expiration_epoch = tonumber(ARGV[10])
 
 -- the key to use for pulling last bucket state from redis
 local lastBucketStateKey = KEYS[1]
@@ -52,7 +52,7 @@ local function takeERLQuota(erlQuotaKey, erl_quota_amount, erl_quota_expiration_
     if erlQuotaExists == 1 then
         erlQuota = tonumber(redis.call('GET', erlQuotaKey))
     end
-    local newERLQuota = erlQuota-1
+    local newERLQuota = erlQuota - 1
     if newERLQuota >= 0 then
         redis.call('SET', erlQuotaKey, newERLQuota, 'PXAT', string.format('%.0f', erl_quota_expiration_epoch))
     end
@@ -66,7 +66,7 @@ redis.replicate_commands()
 
 -- calculate new bucket content
 local bucket_content_after_refill
-if is_erl_activated==1 then
+if is_erl_activated == 1 then
     bucket_content_after_refill = calculateNewBucketContent(current, erl_tokens_per_ms, erl_bucket_size, current_timestamp_ms)
 else
     bucket_content_after_refill = calculateNewBucketContent(current, tokens_per_ms, bucket_size, current_timestamp_ms)
@@ -104,8 +104,8 @@ end
 
 -- save bucket state
 redis.call('HMSET', lastBucketStateKey,
-            'd', current_timestamp_ms,
-            'r', bucket_content_after_take)
+        'd', current_timestamp_ms,
+        'r', bucket_content_after_take)
 redis.call('EXPIRE', lastBucketStateKey, ttl)
 
 local reset_ms = 0
@@ -118,4 +118,4 @@ if drip_interval > 0 then
 end
 
 -- Return the current quota
-return { bucket_content_after_take, enough_tokens, current_timestamp_ms, reset_ms, is_erl_activated, erlQuota}
+return { bucket_content_after_take, enough_tokens, current_timestamp_ms, reset_ms, is_erl_activated, erlQuota }

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -75,6 +75,7 @@ end
 local enough_tokens = bucket_content_after_refill >= tokens_to_take
 local bucket_content_after_take = bucket_content_after_refill
 local erlQuota = -1
+local erl_triggered = false
 
 if enough_tokens then
     if is_erl_activated == 1 then
@@ -97,6 +98,7 @@ else
                 redis.call('SET', erlKey, '1')
                 redis.call('EXPIRE', erlKey, erl_activation_period_seconds)
                 is_erl_activated = 1
+                erl_triggered = true
             end
         end
     end
@@ -118,4 +120,4 @@ if drip_interval > 0 then
 end
 
 -- Return the current quota
-return { bucket_content_after_take, enough_tokens, current_timestamp_ms, reset_ms, is_erl_activated, erlQuota }
+return { bucket_content_after_take, enough_tokens, current_timestamp_ms, reset_ms, erl_triggered, is_erl_activated, erlQuota }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -139,7 +139,7 @@ function randomBetween(min, max) {
   return Math.random() * (max - min) + min;
 }
 
-function extractERLQuota(params) {
+function getERLQuotaAmountAndExpiration(params) {
   const erlQuota = params.erlQuota;
   const type = _.pick(erlQuota, [
     'key',
@@ -172,7 +172,7 @@ module.exports = {
   normalizeType,
   functionOrFalse,
   randomBetween,
-  ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS: ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS,
-  extractERLQuota,
+  ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS,
+  getERLQuotaAmountAndExpiration,
   endOfMonthTimestamp
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -10,7 +10,13 @@ const INTERVAL_TO_MS = {
 };
 
 const INTERVAL_SHORTCUTS = Object.keys(INTERVAL_TO_MS);
+
+const ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH = 'per_cal_month';
+const ERL_QUOTA_INTERVALS= {};
+ERL_QUOTA_INTERVALS[ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH] = () => endOfMonthTimestamp();
+
 const ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS = 15 * 60;
+const ERL_QUOTA_INTERVALS_SHORTCUTS = Object.keys(ERL_QUOTA_INTERVALS);
 
 function normalizeTemporals(params) {
   const type = _.pick(params, [
@@ -131,13 +137,38 @@ function randomBetween(min, max) {
   return Math.random() * (max-min) + min;
 }
 
+function extractERLQuota(params) {
+  const erlQuota = params.erlQuota;
+  const type = _.pick(erlQuota, [
+    'key',
+    'amount',
+    'expiration'
+  ]);
+
+  ERL_QUOTA_INTERVALS_SHORTCUTS.forEach(intervalShortcut => {
+    if (!(intervalShortcut in erlQuota)) { return; }
+    type.amount = erlQuota[intervalShortcut];
+    type.expiration = ERL_QUOTA_INTERVALS[intervalShortcut]();
+  });
+
+  return type;
+}
+
+function endOfMonthTimestamp() {
+  const curDate = new Date();
+  return Date.UTC(curDate.getUTCFullYear(), curDate.getUTCMonth() + 1, 1, 0, 0, 0,0 );
+}
+
 module.exports = {
   buildBuckets,
   buildBucket,
   INTERVAL_SHORTCUTS,
+  ERL_QUOTA_INTERVALS_SHORTCUTS,
   normalizeTemporals,
   normalizeType,
   functionOrFalse,
   randomBetween,
   ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS: ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS,
+  extractERLQuota,
+  endOfMonthTimestamp
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -143,16 +143,16 @@ function getERLKeysQuotaAmountAndExpiration(params) {
   const type = _.pick(params, [
     'erl_is_active_key',
     'erl_quota_key',
-    'amount',
-    'expiration'
+    'erl_quota_amount',
+    'erl_quota_expiration'
   ]);
 
   ERL_QUOTA_INTERVALS_SHORTCUTS.forEach(intervalShortcut => {
     if (!(intervalShortcut in params)) {
       return;
     }
-    type.amount = params[intervalShortcut];
-    type.expiration = ERL_QUOTA_INTERVALS[intervalShortcut]();
+    type.erl_quota_amount = params[intervalShortcut];
+    type.erl_quota_expiration = ERL_QUOTA_INTERVALS[intervalShortcut]();
   });
 
   return type;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -139,19 +139,19 @@ function randomBetween(min, max) {
   return Math.random() * (max - min) + min;
 }
 
-function getERLQuotaAmountAndExpiration(params) {
-  const erlQuota = params.erlQuota;
-  const type = _.pick(erlQuota, [
-    'key',
+function getERLKeysQuotaAmountAndExpiration(params) {
+  const type = _.pick(params, [
+    'erlIsActiveKey',
+    'erlQuotaKey',
     'amount',
     'expiration'
   ]);
 
   ERL_QUOTA_INTERVALS_SHORTCUTS.forEach(intervalShortcut => {
-    if (!(intervalShortcut in erlQuota)) {
+    if (!(intervalShortcut in params)) {
       return;
     }
-    type.amount = erlQuota[intervalShortcut];
+    type.amount = params[intervalShortcut];
     type.expiration = ERL_QUOTA_INTERVALS[intervalShortcut]();
   });
 
@@ -173,6 +173,6 @@ module.exports = {
   functionOrFalse,
   randomBetween,
   ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS,
-  getERLQuotaAmountAndExpiration,
+  getERLKeysQuotaAmountAndExpiration,
   endOfMonthTimestamp
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,7 +11,7 @@ const INTERVAL_TO_MS = {
 
 const INTERVAL_SHORTCUTS = Object.keys(INTERVAL_TO_MS);
 
-const ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH = 'per_cal_month';
+const ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH = 'per_calendar_month';
 const ERL_QUOTA_INTERVALS = {};
 ERL_QUOTA_INTERVALS[ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH] = () => endOfMonthTimestamp();
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,7 +12,7 @@ const INTERVAL_TO_MS = {
 const INTERVAL_SHORTCUTS = Object.keys(INTERVAL_TO_MS);
 
 const ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH = 'per_cal_month';
-const ERL_QUOTA_INTERVALS= {};
+const ERL_QUOTA_INTERVALS = {};
 ERL_QUOTA_INTERVALS[ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH] = () => endOfMonthTimestamp();
 
 const ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS = 15 * 60;
@@ -28,7 +28,9 @@ function normalizeTemporals(params) {
   ]);
 
   INTERVAL_SHORTCUTS.forEach(intervalShortcut => {
-    if (!params[intervalShortcut]) { return; }
+    if (!params[intervalShortcut]) {
+      return;
+    }
     type.interval = INTERVAL_TO_MS[intervalShortcut];
     type.per_interval = params[intervalShortcut];
   });
@@ -125,7 +127,7 @@ function buildBucket(bucket) {
 function functionOrFalse(fun) {
   return !!(fun && fun.constructor && fun.call && fun.apply)
     ? fun
-    : false
+    : false;
 }
 
 function randomBetween(min, max) {
@@ -134,7 +136,7 @@ function randomBetween(min, max) {
     max = min;
     min = tmp;
   }
-  return Math.random() * (max-min) + min;
+  return Math.random() * (max - min) + min;
 }
 
 function extractERLQuota(params) {
@@ -146,7 +148,9 @@ function extractERLQuota(params) {
   ]);
 
   ERL_QUOTA_INTERVALS_SHORTCUTS.forEach(intervalShortcut => {
-    if (!(intervalShortcut in erlQuota)) { return; }
+    if (!(intervalShortcut in erlQuota)) {
+      return;
+    }
     type.amount = erlQuota[intervalShortcut];
     type.expiration = ERL_QUOTA_INTERVALS[intervalShortcut]();
   });
@@ -156,7 +160,7 @@ function extractERLQuota(params) {
 
 function endOfMonthTimestamp() {
   const curDate = new Date();
-  return Date.UTC(curDate.getUTCFullYear(), curDate.getUTCMonth() + 1, 1, 0, 0, 0,0 );
+  return Date.UTC(curDate.getUTCFullYear(), curDate.getUTCMonth() + 1, 1, 0, 0, 0, 0);
 }
 
 module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -141,8 +141,8 @@ function randomBetween(min, max) {
 
 function getERLKeysQuotaAmountAndExpiration(params) {
   const type = _.pick(params, [
-    'erlIsActiveKey',
-    'erlQuotaKey',
+    'erl_is_active_key',
+    'erl_quota_key',
     'amount',
     'expiration'
   ]);

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -59,30 +59,30 @@ function validateOverride(configOverride) {
 }
 
 function validateERLParams(params) {
+  if (!params) {
+    return new LimitdRedisValidationError('elevatedLimits object is required for elevated limits', { code: 107 });
+  }
+
   // redis' way of knowing whether erl is active or not
   if (typeof params.erlIsActiveKey !== 'string') {
-    return new LimitdRedisValidationError('erlIsActiveKey is required for elevated limits', { code: 107 });
+    return new LimitdRedisValidationError('erlIsActiveKey is required for elevated limits', { code: 108 });
   }
 
-  return validateERLQuota(params.erlQuota);
+  return validateERLQuota(params);
 }
 
-function validateERLQuota(quota) {
-  if (typeof quota === 'undefined') {
-    return new LimitdRedisValidationError('erlQuota is required for elevated limits', { code: 109 });
+function validateERLQuota(params) {
+  if (typeof params.erlQuotaKey !== 'string') {
+    return new LimitdRedisValidationError('erlQuotaKey is required for elevated limits', { code: 110 });
   }
 
-  if (typeof quota.key !== 'string') {
-    return new LimitdRedisValidationError('erlQuota.key is required for elevated limits', { code: 110 });
-  }
-
-  if (!containsERLQuotaInterval(quota)) {
-    return new LimitdRedisValidationError('corresponding erlQuota.per_interval is required for elevated limits', { code: 111 });
+  if (!containsERLQuotaInterval(params)) {
+    return new LimitdRedisValidationError('corresponding per_interval is required for elevated limits', { code: 111 });
   }
 }
 
-function containsERLQuotaInterval(quota) {
-  const interval = Object.keys(quota)
+function containsERLQuotaInterval(params) {
+  const interval = Object.keys(params)
     .find(key => ERL_QUOTA_INTERVALS_SHORTCUTS.indexOf(key) > -1);
 
   return interval !== undefined;
@@ -91,7 +91,7 @@ function containsERLQuotaInterval(quota) {
 function validateConfigIsForElevatedBucket(key, bucketKeyConfig) {
   if (!isConfigForElevatedBucket(bucketKeyConfig)) {
     return new LimitdRedisValidationError(`Attempted to takeElevated() for a bucket with no elevated config. bucket:${key}, bucketKeyConfig:${JSON.stringify(bucketKeyConfig)}`,
-      { code: 108 });
+      { code: 109 });
   }
 }
 

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,4 +1,4 @@
-const { INTERVAL_SHORTCUTS } = require('./utils');
+const { INTERVAL_SHORTCUTS, ERL_QUOTA_INTERVALS_SHORTCUTS } = require('./utils');
 
 class LimitdRedisValidationError extends Error {
   constructor(msg, extra) {
@@ -59,10 +59,33 @@ function validateOverride(configOverride) {
 }
 
 function validateERLParams(params) {
-  const erlIsActiveKey = params.erlIsActiveKey; // redis' way of knowing whether erl is active or not
-  if (!erlIsActiveKey)  {
+  // redis' way of knowing whether erl is active or not
+  if (typeof params.erlIsActiveKey !== 'string')  {
     return new LimitdRedisValidationError('erlIsActiveKey is required for elevated limits', { code: 107 });
   }
+
+  return validateERLQuota(params.erlQuota)
+}
+
+function validateERLQuota(quota) {
+  if (typeof quota === 'undefined')  {
+    return new LimitdRedisValidationError('erlQuota is required for elevated limits', { code: 109 });
+  }
+
+  if (typeof quota.key !== 'string')  {
+    return new LimitdRedisValidationError('erlQuota.key is required for elevated limits', { code: 110 });
+  }
+
+  if (!containsERLQuotaInterval(quota))  {
+    return new LimitdRedisValidationError('corresponding erlQuota.per_interval is required for elevated limits', { code: 111 });
+  }
+}
+
+function containsERLQuotaInterval(quota) {
+  const interval = Object.keys(quota)
+    .find(key => ERL_QUOTA_INTERVALS_SHORTCUTS.indexOf(key) > -1)
+
+  return interval !== undefined
 }
 
 function validateConfigIsForElevatedBucket(key, bucketKeyConfig) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -60,32 +60,32 @@ function validateOverride(configOverride) {
 
 function validateERLParams(params) {
   // redis' way of knowing whether erl is active or not
-  if (typeof params.erlIsActiveKey !== 'string')  {
+  if (typeof params.erlIsActiveKey !== 'string') {
     return new LimitdRedisValidationError('erlIsActiveKey is required for elevated limits', { code: 107 });
   }
 
-  return validateERLQuota(params.erlQuota)
+  return validateERLQuota(params.erlQuota);
 }
 
 function validateERLQuota(quota) {
-  if (typeof quota === 'undefined')  {
+  if (typeof quota === 'undefined') {
     return new LimitdRedisValidationError('erlQuota is required for elevated limits', { code: 109 });
   }
 
-  if (typeof quota.key !== 'string')  {
+  if (typeof quota.key !== 'string') {
     return new LimitdRedisValidationError('erlQuota.key is required for elevated limits', { code: 110 });
   }
 
-  if (!containsERLQuotaInterval(quota))  {
+  if (!containsERLQuotaInterval(quota)) {
     return new LimitdRedisValidationError('corresponding erlQuota.per_interval is required for elevated limits', { code: 111 });
   }
 }
 
 function containsERLQuotaInterval(quota) {
   const interval = Object.keys(quota)
-    .find(key => ERL_QUOTA_INTERVALS_SHORTCUTS.indexOf(key) > -1)
+    .find(key => ERL_QUOTA_INTERVALS_SHORTCUTS.indexOf(key) > -1);
 
-  return interval !== undefined
+  return interval !== undefined;
 }
 
 function validateConfigIsForElevatedBucket(key, bucketKeyConfig) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -60,20 +60,20 @@ function validateOverride(configOverride) {
 
 function validateERLParams(params) {
   if (!params) {
-    return new LimitdRedisValidationError('elevatedLimits object is required for elevated limits', { code: 107 });
+    return new LimitdRedisValidationError('elevated_limits object is required for elevated limits', { code: 107 });
   }
 
   // redis' way of knowing whether erl is active or not
-  if (typeof params.erlIsActiveKey !== 'string') {
-    return new LimitdRedisValidationError('erlIsActiveKey is required for elevated limits', { code: 108 });
+  if (typeof params.erl_is_active_key !== 'string') {
+    return new LimitdRedisValidationError('erl_is_active_key is required for elevated limits', { code: 108 });
   }
 
   return validateERLQuota(params);
 }
 
 function validateERLQuota(params) {
-  if (typeof params.erlQuotaKey !== 'string') {
-    return new LimitdRedisValidationError('erlQuotaKey is required for elevated limits', { code: 110 });
+  if (typeof params.erl_quota_key !== 'string') {
+    return new LimitdRedisValidationError('erl_quota_key is required for elevated limits', { code: 110 });
   }
 
   if (!containsERLQuotaInterval(params)) {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint": "^6.1.0",
     "mocha": "^5.2.0",
     "nyc": "^14.1.1",
-    "toxiproxy-node-client": "^2.0.6"
+    "toxiproxy-node-client": "^2.0.6",
+    "mockdate": "^3.0.5"
   }
 }

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -852,7 +852,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_key',
           elevatedLimits : { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
-          allowERL: true,
         };
 
         // erl not activated yet
@@ -865,7 +864,7 @@ describe('LimitDBRedis', () => {
       });
       it('should raise an error if elevatedLimits object is not provided for a bucket with elevated_limits configuration', (done) => {
         const bucketName = 'bucket_with_elevated_limits_config';
-        const params = { type: bucketName, key: 'some_bucket_key', allowERL: true };
+        const params = { type: bucketName, key: 'some_bucket_key' };
         db.configurateBucket(bucketName, {
           size: 1,
           per_minute: 1,
@@ -894,7 +893,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_bucket_key',
           elevatedLimits: { erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
-          allowERL: true,
         };
 
         db.takeElevated(params, (err) => {
@@ -916,7 +914,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_bucket_key',
           elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', per_calendar_month: 10 },
-          allowERL: true,
         };
 
         db.takeElevated(params, (err) => {
@@ -938,7 +935,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_bucket_key',
           elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey' },
-          allowERL: true,
         };
 
         db.takeElevated(params, (err) => {
@@ -960,7 +956,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_bucket_key',
           elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
-          allowERL: true,
         };
 
         // first call, still within normal rate limits
@@ -981,7 +976,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_bucket_key',
           elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
-          allowERL: true,
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1018,7 +1012,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_key ',
           elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
-          allowERL: true,
         };
         await db.configurateBucket(bucketName, {
           size: 2,
@@ -1043,7 +1036,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_key',
           elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
-          allowERL: true,
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1066,7 +1058,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_key',
           elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
-          allowERL: true,
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1090,7 +1081,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_key ',
           elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
-          allowERL: true,
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1118,7 +1108,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_key',
           elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
-          allowERL: true,
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1176,7 +1165,6 @@ describe('LimitDBRedis', () => {
           type: bucketName,
           key: 'some_key',
           elevatedLimits: { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
-          allowERL: true,
         };
         db.takeElevated(params, (err) => {
           assert.match(err.message, /Attempted to takeElevated\(\) for a bucket with no elevated config/);
@@ -1262,7 +1250,6 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_key',
-          allowERL: true
         };
         beforeEach(() => {
           db.configurateBucket(bucketName, {

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -178,7 +178,7 @@ describe('LimitDBRedis', () => {
         name: 'elevated take',
         init: () => db.configurateBuckets(elevatedBuckets),
         take: (params, callback) => db.takeElevated(params, callback),
-        params: { erlIsActiveKey: 'some_erl_active_identifier', erlQuota: { key: 'erlquotakey', per_cal_month: 10 } }
+        params: { erlIsActiveKey: 'some_erl_active_identifier', erlQuota: { key: 'erlquotakey', per_calendar_month: 10 } }
       }
     ];
 
@@ -853,7 +853,7 @@ describe('LimitDBRedis', () => {
           key: 'some_key',
           erlIsActiveKey: erlIsActiveKey,
           allowERL: true,
-          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
+          erlQuota: { key: 'erlquotakey', per_calendar_month: 10 }
         };
 
         // erl not activated yet
@@ -896,7 +896,7 @@ describe('LimitDBRedis', () => {
           key: 'some_bucket_key',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
+          erlQuota: { key: 'erlquotakey', per_calendar_month: 10 }
         };
 
         // first call, still within normal rate limits
@@ -918,7 +918,7 @@ describe('LimitDBRedis', () => {
           key: 'some_bucket_key',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
+          erlQuota: { key: 'erlquotakey', per_calendar_month: 10 }
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -956,7 +956,7 @@ describe('LimitDBRedis', () => {
           key: 'some_key ',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
+          erlQuota: { key: 'erlquotakey', per_calendar_month: 10 }
         };
         await db.configurateBucket(bucketName, {
           size: 2,
@@ -982,7 +982,7 @@ describe('LimitDBRedis', () => {
           key: 'some_key',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
+          erlQuota: { key: 'erlquotakey', per_calendar_month: 10 }
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1006,7 +1006,7 @@ describe('LimitDBRedis', () => {
           key: 'some_key',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
+          erlQuota: { key: 'erlquotakey', per_calendar_month: 10 }
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1031,7 +1031,7 @@ describe('LimitDBRedis', () => {
           key: 'some_key ',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
+          erlQuota: { key: 'erlquotakey', per_calendar_month: 10 }
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1060,7 +1060,7 @@ describe('LimitDBRedis', () => {
           key: 'some_key',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
+          erlQuota: { key: 'erlquotakey', per_calendar_month: 10 }
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1119,7 +1119,7 @@ describe('LimitDBRedis', () => {
           key: 'some_key',
           erlIsActiveKey: erlIsActiveKey,
           allowERL: true,
-          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
+          erlQuota: { key: 'erlquotakey', per_calendar_month: 10 }
         };
         db.takeElevated(params, (err) => {
           assert.match(err.message, /Attempted to takeElevated\(\) for a bucket with no elevated config/);
@@ -1140,7 +1140,7 @@ describe('LimitDBRedis', () => {
             type: bucketName,
             key: 'some_key',
             erlIsActiveKey: erlIsActiveKey,
-            erlQuota: { key: 'erlquotakey', per_cal_month: 10 },
+            erlQuota: { key: 'erlquotakey', per_calendar_month: 10 },
             configOverride
           };
           takeElevatedPromise(params)
@@ -1180,7 +1180,7 @@ describe('LimitDBRedis', () => {
             type: bucketName,
             key: 'some_key',
             erlIsActiveKey: erlIsActiveKey,
-            erlQuota: { key: 'erlquotakey', per_cal_month: 10 },
+            erlQuota: { key: 'erlquotakey', per_calendar_month: 10 },
             configOverride
           };
           takeElevatedPromise(params)
@@ -1229,7 +1229,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should return erl_quota_count >= 0 when ERL gets activated', (done) => {
-          params.erlQuota = { key: 'erlquotakey', per_cal_month: 10 };
+          params.erlQuota = { key: 'erlquotakey', per_calendar_month: 10 };
 
           // check erl not activated yet
           redisExistsPromise(erlIsActiveKey)
@@ -1248,11 +1248,11 @@ describe('LimitDBRedis', () => {
         });
 
         it('should return erl_quota_count = -1 when ERL had already been activated', (done) => {
-          params.erlQuota = { key: 'erlquotakey', per_cal_month: 10 };
+          params.erlQuota = { key: 'erlquotakey', per_calendar_month: 10 };
 
           // setup ERL
           redisSetPromise(erlIsActiveKey, 1)
-            .then(() => redisSetPromise(params.erlQuota.key, params.erlQuota.per_cal_month - 1))
+            .then(() => redisSetPromise(params.erlQuota.key, params.erlQuota.per_calendar_month - 1))
             // takeElevated with ERL activated
             .then(() => takeElevatedPromise(params))
             .then((response) => assert.isTrue(response.erl_activated) && assert.equal(response.erl_quota_count, -1))
@@ -1260,7 +1260,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should set ttl accordingly on erlQuotaKey when we activate ERL', (done) => {
-          params.erlQuota = { key: 'erlquotakey', per_cal_month: 10 };
+          params.erlQuota = { key: 'erlquotakey', per_calendar_month: 10 };
 
           const eom = endOfMonthTimestamp();
           // get ms between now and eom
@@ -1282,7 +1282,7 @@ describe('LimitDBRedis', () => {
             .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 1))
             // check erlQuota should be decreased by 1
             .then(() => redisGetPromise(params.erlQuota.key))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.erlQuota.per_cal_month - 1))
+            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.erlQuota.per_calendar_month - 1))
             // check ttl on erlQuotaKey
             .then(() => redisTTLPromise(params.erlQuota.key))
             .then((ttl) => assert.closeTo(ttl, expectedTTL, 2))
@@ -1290,7 +1290,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should keep ttl on erlQuotaKey after decreasing it', (done) => {
-          params.erlQuota = { key: 'erlquotakey', per_cal_month: 10 };
+          params.erlQuota = { key: 'erlquotakey', per_calendar_month: 10 };
           let expectedTTL = 0;
 
           // check erl not activated yet
@@ -1309,7 +1309,7 @@ describe('LimitDBRedis', () => {
             .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 1))
             // check erlQuota should be decreased by 1
             .then(() => redisGetPromise(params.erlQuota.key))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.erlQuota.per_cal_month - 1))
+            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.erlQuota.per_calendar_month - 1))
             // check ttl on erlQuotaKey
             .then(() => redisTTLPromise(params.erlQuota.key))
             .then((ttl) => expectedTTL = ttl)
@@ -1321,7 +1321,7 @@ describe('LimitDBRedis', () => {
             .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 1))
             // check erlQuota should be decreased by 1
             .then(() => redisGetPromise(params.erlQuota.key))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.erlQuota.per_cal_month - 2))
+            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.erlQuota.per_calendar_month - 2))
             // check erlQuota keeps the TTL
             .then(() => redisTTLPromise(params.erlQuota.key))
             .then((ttl) => assert.equal(ttl, expectedTTL))
@@ -1329,9 +1329,9 @@ describe('LimitDBRedis', () => {
         });
 
         it('should decrease erlQuota when we activate ERL', (done) => {
-          // activating ERL with per_cal_month=1 is testing a border case to make sure decreasing the quota
+          // activating ERL with per_calendar_month=1 is testing a border case to make sure decreasing the quota
           // is not interpreted in the script as no quota left for activating ERL
-          params.erlQuota = { key: 'erlquotakey', per_cal_month: 1 };
+          params.erlQuota = { key: 'erlquotakey', per_calendar_month: 1 };
 
           // check erl not activated yet
           redisExistsPromise(erlIsActiveKey)
@@ -1351,12 +1351,12 @@ describe('LimitDBRedis', () => {
             .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 1))
             // check erlQuota should be decreased by 1
             .then(() => redisGetPromise(params.erlQuota.key))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.erlQuota.per_cal_month - 1))
+            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.erlQuota.per_calendar_month - 1))
             .then(() => done());
         });
 
         it('should not activate ERL when erlQuota is 0', (done) => {
-          params.erlQuota = { key: 'erlquotakey', per_cal_month: 0 };
+          params.erlQuota = { key: 'erlquotakey', per_calendar_month: 0 };
 
           // check erl not activated yet
           redisExistsPromise(erlIsActiveKey)
@@ -1381,7 +1381,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should activate ERL when erlQuota is 1', (done) => {
-          params.erlQuota = { key: 'erlquotakey', per_cal_month: 1 };
+          params.erlQuota = { key: 'erlquotakey', per_calendar_month: 1 };
 
           // check erl not activated yet
           redisExistsPromise(erlIsActiveKey)
@@ -1406,7 +1406,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should not activate ERL if erlQuotaKey exists and is 0', (done) => {
-          params.erlQuota = { key: 'erlquotakey', per_cal_month: 10 };
+          params.erlQuota = { key: 'erlquotakey', per_calendar_month: 10 };
 
           // set erlQuotaKey to 0 in redis
           redisSetPromise(params.erlQuota.key, 0)
@@ -1432,7 +1432,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should activate ERL after erlQuotaKey=0 expires', (done) => {
-          params.erlQuota = { key: 'erlquotakey', per_cal_month: 10 };
+          params.erlQuota = { key: 'erlquotakey', per_calendar_month: 10 };
 
           // set erlQuotaKey to 0 in redis
           redisSetWithExpirePromise(params.erlQuota.key, 0, 1)

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -1380,31 +1380,6 @@ describe('LimitDBRedis', () => {
             .then(() => done());
         });
 
-        it('should activate ERL when erlQuota is 1', (done) => {
-          params.erlQuota = { key: 'erlquotakey', per_calendar_month: 1 };
-
-          // check erl not activated yet
-          redisExistsPromise(erlIsActiveKey)
-            .then((erlIsActiveExists) => assert.equal(erlIsActiveExists, 0))
-            // check erlQuotaKey does not exist
-            .then(() => redisExistsPromise(params.erlQuota.key)
-              .then((erlQuotaKeyExists) => assert.equal(erlQuotaKeyExists, 0)))
-            // attempt to take elevated should work for first token
-            .then(() => takeElevatedPromise(params))
-            .then((result) => assert.isTrue(result.conformant) && assert.isFalse(result.erl_activated))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 0))
-            // next takeElevated should activate ERL and return conformant
-            .then(() => takeElevatedPromise(params))
-            .then((result) => assert.isTrue(result.conformant) && assert.isTrue(result.erl_activated))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 1))
-            // check erlQuota was decreased by 1 and now it should be 0
-            .then(() => redisGetPromise(params.erlQuota.key))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, 0))
-            .then(() => done());
-        });
-
         it('should not activate ERL if erlQuotaKey exists and is 0', (done) => {
           params.erlQuota = { key: 'erlquotakey', per_calendar_month: 10 };
 

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -178,7 +178,7 @@ describe('LimitDBRedis', () => {
         name: 'elevated take',
         init: () => db.configurateBuckets(elevatedBuckets),
         take: (params, callback) => db.takeElevated(params, callback),
-        params: { elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 } }
+        params: { elevated_limits: { erl_is_active_key: 'some_erl_active_identifier', erl_quota_key: 'erlquotakey', per_calendar_month: 10 } }
       }
     ];
 
@@ -837,9 +837,9 @@ describe('LimitDBRedis', () => {
         });
       });
 
-      it('should set a key at erlIsActiveKey when erl is activated for a bucket with elevated_limits configuration', async () => {
+      it('should set a key at erl_is_active_key when erl is activated for a bucket with elevated_limits configuration', async () => {
         const bucketName = 'bucket_with_elevated_limits_config';
-        const erlIsActiveKey = 'some_erl_active_identifier';
+        const erl_is_active_key = 'some_erl_active_identifier';
         db.configurateBucket(bucketName, {
           size: 1,
           per_minute: 1,
@@ -851,18 +851,18 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_key',
-          elevatedLimits : { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+          elevated_limits : { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
         };
 
         // erl not activated yet
         await takeElevatedPromise(params);
-        await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 0));
+        await redisExistsPromise(erl_is_active_key).then((isActive) => assert.equal(isActive, 0));
 
         // erl now activated
         await takeElevatedPromise(params);
-        await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 1));
+        await redisExistsPromise(erl_is_active_key).then((isActive) => assert.equal(isActive, 1));
       });
-      it('should raise an error if elevatedLimits object is not provided for a bucket with elevated_limits configuration', (done) => {
+      it('should raise an error if elevated_limits object is not provided for a bucket with elevated_limits configuration', (done) => {
         const bucketName = 'bucket_with_elevated_limits_config';
         const params = { type: bucketName, key: 'some_bucket_key' };
         db.configurateBucket(bucketName, {
@@ -875,11 +875,11 @@ describe('LimitDBRedis', () => {
         });
 
         db.takeElevated(params, (err) => {
-          assert.match(err.message, /elevatedLimits object is required for elevated limits/);
+          assert.match(err.message, /elevated_limits object is required for elevated limits/);
           done();
         });
       });
-      it('should raise an error if elevatedLimits.erlIsActiveKey is not provided for a bucket with elevated_limits configuration', (done) => {
+      it('should raise an error if elevated_limits.erl_is_active_key is not provided for a bucket with elevated_limits configuration', (done) => {
         const bucketName = 'bucket_with_elevated_limits_config';
         db.configurateBucket(bucketName, {
           size: 1,
@@ -892,15 +892,15 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_bucket_key',
-          elevatedLimits: { erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+          elevated_limits: { erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
         };
 
         db.takeElevated(params, (err) => {
-          assert.match(err.message, /erlIsActiveKey is required for elevated limits/);
+          assert.match(err.message, /erl_is_active_key is required for elevated limits/);
           done();
         });
       });
-      it('should raise an error if elevatedLimits.erlQuotaKey is not provided for a bucket with elevated_limits configuration', (done) => {
+      it('should raise an error if elevated_limits.erl_quota_key is not provided for a bucket with elevated_limits configuration', (done) => {
         const bucketName = 'bucket_with_elevated_limits_config';
         db.configurateBucket(bucketName, {
           size: 1,
@@ -913,15 +913,15 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_bucket_key',
-          elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', per_calendar_month: 10 },
+          elevated_limits: { erl_is_active_key: 'some_erl_active_identifier', per_calendar_month: 10 },
         };
 
         db.takeElevated(params, (err) => {
-          assert.match(err.message, /erlQuotaKey is required for elevated limits/);
+          assert.match(err.message, /erl_quota_key is required for elevated limits/);
           done();
         });
       });
-      it('should raise an error if elevatedLimits.per_calendar_month is not provided for a bucket with elevated_limits configuration', (done) => {
+      it('should raise an error if elevated_limits.per_calendar_month is not provided for a bucket with elevated_limits configuration', (done) => {
         const bucketName = 'bucket_with_elevated_limits_config';
         db.configurateBucket(bucketName, {
           size: 1,
@@ -934,7 +934,7 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_bucket_key',
-          elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey' },
+          elevated_limits: { erl_is_active_key: 'some_erl_active_identifier', erl_quota_key: 'erlquotakey' },
         };
 
         db.takeElevated(params, (err) => {
@@ -955,7 +955,7 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_bucket_key',
-          elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+          elevated_limits: { erl_is_active_key: 'some_erl_active_identifier', erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
         };
 
         // first call, still within normal rate limits
@@ -975,7 +975,7 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_bucket_key',
-          elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+          elevated_limits: { erl_is_active_key: 'some_erl_active_identifier', erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1011,7 +1011,7 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_key ',
-          elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+          elevated_limits: { erl_is_active_key: 'some_erl_active_identifier', erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
         };
         await db.configurateBucket(bucketName, {
           size: 2,
@@ -1035,7 +1035,7 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_key',
-          elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+          elevated_limits: { erl_is_active_key: 'some_erl_active_identifier', erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1057,7 +1057,7 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_key',
-          elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+          elevated_limits: { erl_is_active_key: 'some_erl_active_identifier', erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1080,7 +1080,7 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_key ',
-          elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+          elevated_limits: { erl_is_active_key: 'some_erl_active_identifier', erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1107,7 +1107,7 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_key',
-          elevatedLimits: { erlIsActiveKey: 'some_erl_active_identifier', erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+          elevated_limits: { erl_is_active_key: 'some_erl_active_identifier', erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1157,7 +1157,7 @@ describe('LimitDBRedis', () => {
 
       it('should return an error when attempting to takeElevated with no elevate config', (done) => {
         const bucketName = 'bucket_with_no_elevated_limits_config';
-        const erlIsActiveKey = 'some_erl_active_identifier';
+        const erl_is_active_key = 'some_erl_active_identifier';
         db.configurateBucket(bucketName, {
           size: 1,
           per_minute: 1
@@ -1165,7 +1165,7 @@ describe('LimitDBRedis', () => {
         const params = {
           type: bucketName,
           key: 'some_key',
-          elevatedLimits: { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+          elevated_limits: { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
         };
         db.takeElevated(params, (err) => {
           assert.match(err.message, /Attempted to takeElevated\(\) for a bucket with no elevated config/);
@@ -1176,7 +1176,7 @@ describe('LimitDBRedis', () => {
       describe('overrides', () => {
         it('should use elevated_limits config override when provided', (done) => {
           const bucketName = 'bucket_with_no_elevated_limits_config';
-          const erlIsActiveKey = 'some_erl_active_identifier';
+          const erl_is_active_key = 'some_erl_active_identifier';
           db.configurateBucket(bucketName, {
             size: 1,
             per_minute: 1
@@ -1185,7 +1185,7 @@ describe('LimitDBRedis', () => {
           const params = {
             type: bucketName,
             key: 'some_key',
-            elevatedLimits: { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+            elevated_limits: { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
             configOverride
           };
           takeElevatedPromise(params)
@@ -1203,7 +1203,7 @@ describe('LimitDBRedis', () => {
             .then(() => takeElevatedPromise(params))
             .then((result) => {
               assert.isFalse(result.conformant);
-              db.redis.ttl(erlIsActiveKey, (err, ttl) => {
+              db.redis.ttl(erl_is_active_key, (err, ttl) => {
                 assert.equal(ttl, ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS); // uses default activation period
                 done();
               });
@@ -1211,7 +1211,7 @@ describe('LimitDBRedis', () => {
         });
         it('should use erl_activation_period from elevated_limits config override when provided', (done) => {
           const bucketName = 'bucket_with_no_elevated_limits_config';
-          const erlIsActiveKey = 'some_erl_active_identifier';
+          const erl_is_active_key = 'some_erl_active_identifier';
           db.configurateBucket(bucketName, {
             size: 1,
             per_minute: 1,
@@ -1224,7 +1224,7 @@ describe('LimitDBRedis', () => {
           const params = {
             type: bucketName,
             key: 'some_key',
-            elevatedLimits: { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 },
+            elevated_limits: { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
             configOverride
           };
           takeElevatedPromise(params)
@@ -1236,7 +1236,7 @@ describe('LimitDBRedis', () => {
             .then((result) => {
               assert.isTrue(result.conformant);
               assert.isTrue(result.elevated_limits.activated);
-              db.redis.ttl(erlIsActiveKey, (err, ttl) => {
+              db.redis.ttl(erl_is_active_key, (err, ttl) => {
                 assert.equal(ttl, 60); // uses specified activation period
                 done();
               });
@@ -1247,7 +1247,7 @@ describe('LimitDBRedis', () => {
       // erlquota tests
       describe('erlQuota tests', () => {
         const bucketName = 'bucket_for_erl_testing';
-        const erlIsActiveKey = 'some_erl_active_identifier';
+        const erl_is_active_key = 'some_erl_active_identifier';
         const params = {
           type: bucketName,
           key: 'some_key',
@@ -1264,18 +1264,18 @@ describe('LimitDBRedis', () => {
         });
 
         it('should return erl_quota_count >= 0 when ERL is triggered', (done) => {
-          params.elevatedLimits = { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 };
+          params.elevated_limits = { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 10 };
 
           // check erl not activated yet
-          redisExistsPromise(erlIsActiveKey)
+          redisExistsPromise(erl_is_active_key)
             .then((erlIsActiveExists) => assert.equal(erlIsActiveExists, 0))
-            // check erlQuotaKey does not exist
-            .then(() => redisExistsPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyExists) => assert.equal(erlQuotaKeyExists, 0))
+            // check erl_quota_key does not exist
+            .then(() => redisExistsPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyExists) => assert.equal(erl_quota_keyExists, 0))
             // attempt to take elevated should work for first token
             .then(() => takeElevatedPromise(params))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 0))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
             // next takeElevated should activate ERL
             .then(() => takeElevatedPromise(params))
             .then((response) => assert.isTrue(response.elevated_limits.triggered) && assert.isTrue(response.elevated_limits.activated) && assert.isAtLeast(response.elevated_limits.quota_count, 0))
@@ -1283,82 +1283,82 @@ describe('LimitDBRedis', () => {
         });
 
         it('should return erl_quota_count = -1 when ERL had already been activated', (done) => {
-          params.elevatedLimits = { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 };
+          params.elevated_limits = { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 10 };
 
           // setup ERL
-          redisSetPromise(erlIsActiveKey, 1)
-            .then(() => redisSetPromise(params.elevatedLimits.erlQuotaKey, params.elevatedLimits.per_calendar_month - 1))
+          redisSetPromise(erl_is_active_key, 1)
+            .then(() => redisSetPromise(params.elevated_limits.erl_quota_key, params.elevated_limits.per_calendar_month - 1))
             // takeElevated with ERL activated
             .then(() => takeElevatedPromise(params))
             .then((response) => assert.isFalse(response.elevated_limits.triggered) && assert.isTrue(response.elevated_limits.activated) && assert.equal(response.elevated_limits.quota_count, -1))
             .then(() => done());
         });
 
-        it('should set ttl accordingly on erlQuotaKey when we activate ERL', (done) => {
-          params.elevatedLimits = { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 };
+        it('should set ttl accordingly on erl_quota_key when we activate ERL', (done) => {
+          params.elevated_limits = { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 10 };
 
           const eom = endOfMonthTimestamp();
           // get ms between now and eom
           const expectedTTL = Math.floor((eom - Date.now()) / 1000);
 
           // check erl not activated yet
-          redisExistsPromise(erlIsActiveKey)
+          redisExistsPromise(erl_is_active_key)
             .then((erlIsActiveExists) => assert.equal(erlIsActiveExists, 0))
-            // check erlQuotaKey does not exist
-            .then(() => redisExistsPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyExists) => assert.equal(erlQuotaKeyExists, 0))
+            // check erl_quota_key does not exist
+            .then(() => redisExistsPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyExists) => assert.equal(erl_quota_keyExists, 0))
             // attempt to take elevated should work for first token
             .then(() => takeElevatedPromise(params))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 0))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
             // next takeElevated should activate ERL
             .then(() => takeElevatedPromise(params))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 1))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 1))
             // check erlQuota should be decreased by 1
-            .then(() => redisGetPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.elevatedLimits.per_calendar_month - 1))
-            // check ttl on erlQuotaKey
-            .then(() => redisTTLPromise(params.elevatedLimits.erlQuotaKey))
+            .then(() => redisGetPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyValue) => assert.equal(erl_quota_keyValue, params.elevated_limits.per_calendar_month - 1))
+            // check ttl on erl_quota_key
+            .then(() => redisTTLPromise(params.elevated_limits.erl_quota_key))
             .then((ttl) => assert.closeTo(ttl, expectedTTL, 2))
             .then(() => done());
         });
 
-        it('should keep ttl on erlQuotaKey after decreasing it', (done) => {
-          params.elevatedLimits = { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 };
+        it('should keep ttl on erl_quota_key after decreasing it', (done) => {
+          params.elevated_limits = { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 10 };
           let expectedTTL = 0;
 
           // check erl not activated yet
-          redisExistsPromise(erlIsActiveKey)
+          redisExistsPromise(erl_is_active_key)
             .then((erlIsActiveExists) => assert.equal(erlIsActiveExists, 0))
-            // check erlQuotaKey does not exist
-            .then(() => redisExistsPromise(params.elevatedLimits.erlQuotaKey)
-              .then((erlQuotaKeyExists) => assert.equal(erlQuotaKeyExists, 0)))
+            // check erl_quota_key does not exist
+            .then(() => redisExistsPromise(params.elevated_limits.erl_quota_key)
+              .then((erl_quota_keyExists) => assert.equal(erl_quota_keyExists, 0)))
             // attempt to take elevated should work for first token
             .then(() => takeElevatedPromise(params))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 0))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
             // next takeElevated should activate ERL
             .then(() => takeElevatedPromise(params))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 1))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 1))
             // check erlQuota should be decreased by 1
-            .then(() => redisGetPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.elevatedLimits.per_calendar_month - 1))
-            // check ttl on erlQuotaKey
-            .then(() => redisTTLPromise(params.elevatedLimits.erlQuotaKey))
+            .then(() => redisGetPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyValue) => assert.equal(erl_quota_keyValue, params.elevated_limits.per_calendar_month - 1))
+            // check ttl on erl_quota_key
+            .then(() => redisTTLPromise(params.elevated_limits.erl_quota_key))
             .then((ttl) => expectedTTL = ttl)
             // stop ERL
-            .then(() => redisDeletePromise(erlIsActiveKey))
+            .then(() => redisDeletePromise(erl_is_active_key))
             // next takeElevated should re-activate ERL
             .then(() => takeElevatedPromise(params))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 1))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 1))
             // check erlQuota should be decreased by 1
-            .then(() => redisGetPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.elevatedLimits.per_calendar_month - 2))
+            .then(() => redisGetPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyValue) => assert.equal(erl_quota_keyValue, params.elevated_limits.per_calendar_month - 2))
             // check erlQuota keeps the TTL
-            .then(() => redisTTLPromise(params.elevatedLimits.erlQuotaKey))
+            .then(() => redisTTLPromise(params.elevated_limits.erl_quota_key))
             .then((ttl) => assert.equal(ttl, expectedTTL))
             .then(() => done());
         });
@@ -1366,120 +1366,120 @@ describe('LimitDBRedis', () => {
         it('should decrease erlQuota when we activate ERL', (done) => {
           // activating ERL with per_calendar_month=1 is testing a border case to make sure decreasing the quota
           // is not interpreted in the script as no quota left for activating ERL
-          params.elevatedLimits = { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 1 };
+          params.elevated_limits = { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 1 };
 
           // check erl not activated yet
-          redisExistsPromise(erlIsActiveKey)
+          redisExistsPromise(erl_is_active_key)
             .then((erlIsActiveExists) => assert.equal(erlIsActiveExists, 0))
-            // check erlQuotaKey does not exist
-            .then(() => redisExistsPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyExists) => assert.equal(erlQuotaKeyExists, 0))
+            // check erl_quota_key does not exist
+            .then(() => redisExistsPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyExists) => assert.equal(erl_quota_keyExists, 0))
             // attempt to take elevated should work for first token
             .then(() => takeElevatedPromise(params))
             .then((result) => assert.isTrue(result.conformant) && assert.isFalse(result.elevated_limits.activated))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 0))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
             // next takeElevated should activate ERL and return conformant
             .then(() => takeElevatedPromise(params))
             .then((result) => assert.isTrue(result.conformant) && assert.isTrue(result.elevated_limits.activated))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 1))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 1))
             // check erlQuota should be decreased by 1
-            .then(() => redisGetPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, params.elevatedLimits.per_calendar_month - 1))
+            .then(() => redisGetPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyValue) => assert.equal(erl_quota_keyValue, params.elevated_limits.per_calendar_month - 1))
             .then(() => done());
         });
 
         it('should not activate ERL when erlQuota is 0', (done) => {
-          params.elevatedLimits = { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 0 };
+          params.elevated_limits = { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 0 };
 
           // check erl not activated yet
-          redisExistsPromise(erlIsActiveKey)
+          redisExistsPromise(erl_is_active_key)
             .then((erlIsActiveExists) => assert.equal(erlIsActiveExists, 0))
-            // check erlQuotaKey does not exist
-            .then(() => redisExistsPromise(params.elevatedLimits.erlQuotaKey)
-              .then((erlQuotaKeyExists) => assert.equal(erlQuotaKeyExists, 0)))
+            // check erl_quota_key does not exist
+            .then(() => redisExistsPromise(params.elevated_limits.erl_quota_key)
+              .then((erl_quota_keyExists) => assert.equal(erl_quota_keyExists, 0)))
             // attempt to take elevated should work for first token
             .then(() => takeElevatedPromise(params))
             .then((result) => assert.isTrue(result.conformant) && assert.isFalse(result.elevated_limits.activated))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 0))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
             // next takeElevated should have attempted to activate ERL but failed
             .then(() => takeElevatedPromise(params))
             .then((result) => assert.isFalse(result.conformant) && assert.isFalse(result.elevated_limits.activated))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 0))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
             // check erlQuota was not set
-            .then(() => redisGetPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyValue) => assert.isNull(erlQuotaKeyValue, 0))
+            .then(() => redisGetPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyValue) => assert.isNull(erl_quota_keyValue, 0))
             .then(() => done());
         });
 
-        it('should not activate ERL if erlQuotaKey exists and is 0', (done) => {
-          params.elevatedLimits = { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 };
+        it('should not activate ERL if erl_quota_key exists and is 0', (done) => {
+          params.elevated_limits = { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 10 };
 
-          // set erlQuotaKey to 0 in redis
-          redisSetPromise(params.elevatedLimits.erlQuotaKey, 0)
-            .then(() => redisGetPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, 0))
+          // set erl_quota_key to 0 in redis
+          redisSetPromise(params.elevated_limits.erl_quota_key, 0)
+            .then(() => redisGetPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyValue) => assert.equal(erl_quota_keyValue, 0))
             // check erl not activated yet
-            .then(() => redisExistsPromise(erlIsActiveKey))
+            .then(() => redisExistsPromise(erl_is_active_key))
             .then((erlIsActiveExists) => assert.equal(erlIsActiveExists, 0))
             // attempt to take elevated should work for first token
             .then(() => takeElevatedPromise(params))
             .then((result) => assert.isTrue(result.conformant) && assert.isFalse(result.elevated_limits.activated))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 0))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
             // next takeElevated should have attempted to activate ERL but failed as quota is 0
             .then(() => takeElevatedPromise(params))
             .then((result) => assert.isFalse(result.conformant) && assert.isFalse(result.elevated_limits.activated))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 0))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
             // check erlQuota is still 0
-            .then(() => redisGetPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, 0))
+            .then(() => redisGetPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyValue) => assert.equal(erl_quota_keyValue, 0))
             .then(() => done());
         });
 
-        it('should activate ERL after erlQuotaKey=0 expires', (done) => {
-          params.elevatedLimits = { erlIsActiveKey: erlIsActiveKey, erlQuotaKey: 'erlquotakey', per_calendar_month: 10 };
+        it('should activate ERL after erl_quota_key=0 expires', (done) => {
+          params.elevated_limits = { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 10 };
 
-          // set erlQuotaKey to 0 in redis
-          redisSetWithExpirePromise(params.elevatedLimits.erlQuotaKey, 0, 1)
-            .then(() => redisGetPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, 0))
-            .then(() => redisTTLPromise(params.elevatedLimits.erlQuotaKey))
+          // set erl_quota_key to 0 in redis
+          redisSetWithExpirePromise(params.elevated_limits.erl_quota_key, 0, 1)
+            .then(() => redisGetPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyValue) => assert.equal(erl_quota_keyValue, 0))
+            .then(() => redisTTLPromise(params.elevated_limits.erl_quota_key))
             .then((quotaTTL) => assert.equal(quotaTTL, 1))
             // check erl not activated yet
-            .then(() => redisExistsPromise(erlIsActiveKey))
+            .then(() => redisExistsPromise(erl_is_active_key))
             .then((erlIsActiveExists) => assert.equal(erlIsActiveExists, 0))
             // attempt to take elevated should work for first token
             .then(() => takeElevatedPromise(params))
             .then((result) => assert.isTrue(result.conformant) && assert.isFalse(result.elevated_limits.activated))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 0))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
             // next takeElevated should have attempted to activate ERL but failed as quota is 0
             .then(() => takeElevatedPromise(params))
             .then((result) => assert.isFalse(result.conformant) && assert.isFalse(result.elevated_limits.activated))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 0))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
             // check erlQuota is still 0
-            .then(() => redisGetPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, 0))
-            // wait for a second for erlQuotaKey to expire
+            .then(() => redisGetPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyValue) => assert.equal(erl_quota_keyValue, 0))
+            // wait for a second for erl_quota_key to expire
             .then(() => new Promise((resolve) => setTimeout(resolve, 1000)))
-            .then(() => redisTTLPromise(params.elevatedLimits.erlQuotaKey))
+            .then(() => redisTTLPromise(params.elevated_limits.erl_quota_key))
             .then((quotaTTL) => assert.isBelow(quotaTTL, 0))
-            .then(() => redisGetPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyValue) => assert.isNull(erlQuotaKeyValue))
+            .then(() => redisGetPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyValue) => assert.isNull(erl_quota_keyValue))
             // next takeElevated should activate ERL and return conformant
             .then(() => takeElevatedPromise(params))
             .then((result) => assert.isTrue(result.conformant) && assert.isTrue(result.elevated_limits.activated))
-            .then(() => redisExistsPromise(erlIsActiveKey))
-            .then((erlIsActiveKeyExists) => assert.equal(erlIsActiveKeyExists, 1))
+            .then(() => redisExistsPromise(erl_is_active_key))
+            .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 1))
             // check erlQuota was decreased
-            .then(() => redisGetPromise(params.elevatedLimits.erlQuotaKey))
-            .then((erlQuotaKeyValue) => assert.equal(erlQuotaKeyValue, 9))
+            .then(() => redisGetPromise(params.elevated_limits.erl_quota_key))
+            .then((erl_quota_keyValue) => assert.equal(erl_quota_keyValue, 9))
             .then(() => done());
         });
       });

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -1,12 +1,12 @@
 /* eslint-env node, mocha */
-const ms       = require('ms');
-const async    = require('async');
-const _        = require('lodash');
-const LimitDB  = require('../lib/db');
-const assert   = require('chai').assert;
-const {Toxiproxy, Toxic} = require('toxiproxy-node-client');
-const crypto  = require('crypto')
-const {ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS, endOfMonthTimestamp} = require("../lib/utils");
+const ms = require('ms');
+const async = require('async');
+const _ = require('lodash');
+const LimitDB = require('../lib/db');
+const assert = require('chai').assert;
+const { Toxiproxy, Toxic } = require('toxiproxy-node-client');
+const crypto = require('crypto');
+const { ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS, endOfMonthTimestamp } = require('../lib/utils');
 
 const buckets = {
   ip: {
@@ -110,7 +110,7 @@ const elevatedBuckets = {
       per_minute: buckets.tenant.per_second,
     },
   },
-}
+};
 
 describe('LimitDBRedis', () => {
   let db;
@@ -158,7 +158,7 @@ describe('LimitDBRedis', () => {
       assert.containsAllKeys(db.buckets, ['ip', 'test']);
     });
 
-    it('should replace configuration of existing type',  () => {
+    it('should replace configuration of existing type', () => {
       db.configurateBucket('ip', { size: 1 });
       assert.equal(db.buckets.ip.size, 1);
       assert.equal(Object.keys(db.buckets.ip.overrides).length, 0);
@@ -169,7 +169,8 @@ describe('LimitDBRedis', () => {
     const testsParams = [
       {
         name: 'regular take',
-        init: () => {},
+        init: () => {
+        },
         take: (params, callback) => db.take(params, callback),
         params: {}
       },
@@ -177,15 +178,15 @@ describe('LimitDBRedis', () => {
         name: 'elevated take',
         init: () => db.configurateBuckets(elevatedBuckets),
         take: (params, callback) => db.takeElevated(params, callback),
-        params: {erlIsActiveKey: 'some_erl_active_identifier', erlQuota: {key: 'erlquotakey', per_cal_month: 10}}
+        params: { erlIsActiveKey: 'some_erl_active_identifier', erlQuota: { key: 'erlquotakey', per_cal_month: 10 } }
       }
-    ]
+    ];
 
     testsParams.forEach(testParams => {
       describe(`${testParams.name}`, () => {
         it(`should fail on validation`, (done) => {
           testParams.init();
-          testParams.take({...testParams.params}, (err) => {
+          testParams.take({ ...testParams.params }, (err) => {
             assert.match(err.message, /type is required/);
             done();
           });
@@ -193,7 +194,7 @@ describe('LimitDBRedis', () => {
 
         it(`should keep track of a key`, (done) => {
           testParams.init();
-          const params = {...testParams.params, type: 'ip',  key: '21.17.65.41'};
+          const params = { ...testParams.params, type: 'ip', key: '21.17.65.41' };
           testParams.take(params, (err) => {
             if (err) {
               return done(err);
@@ -211,7 +212,7 @@ describe('LimitDBRedis', () => {
 
         it(`should add a ttl to buckets`, (done) => {
           testParams.init();
-          const params = {...testParams.params, type: 'ip', key: '211.45.66.1'};
+          const params = { ...testParams.params, type: 'ip', key: '211.45.66.1' };
           testParams.take(params, (err) => {
             if (err) {
               return done(err);
@@ -232,14 +233,14 @@ describe('LimitDBRedis', () => {
           testParams.take({
             ...testParams.params,
             type: 'ip',
-            key:  '5.5.5.5'
+            key: '5.5.5.5'
           }, (err) => {
             if (err) {
               return done(err);
             }
             db.put({
               type: 'ip',
-              key:  '5.5.5.5',
+              key: '5.5.5.5',
             }, (err) => {
               if (err) {
                 return done(err);
@@ -247,7 +248,7 @@ describe('LimitDBRedis', () => {
               testParams.take({
                 ...testParams.params,
                 type: 'ip',
-                key:  '5.5.5.5'
+                key: '5.5.5.5'
               }, (err, result) => {
                 if (err) {
                   return done(err);
@@ -269,7 +270,7 @@ describe('LimitDBRedis', () => {
           testParams.take({
             ...testParams.params,
             type: 'ip',
-            key:  '1.1.1.1'
+            key: '1.1.1.1'
           }, (err, result) => {
             if (err) return done(err);
             assert.ok(result.conformant);
@@ -285,8 +286,8 @@ describe('LimitDBRedis', () => {
           const now = Date.now();
           testParams.take({
             ...testParams.params,
-            type:  'ip',
-            key:   '2.2.2.2',
+            type: 'ip',
+            key: '2.2.2.2',
             count: 12
           }, (err, result) => {
             if (err) return done(err);
@@ -302,14 +303,16 @@ describe('LimitDBRedis', () => {
           testParams.init();
           const takeParams = {
             ...testParams.params,
-            type:  'ip',
-            key:   '3.3.3.3'
+            type: 'ip',
+            key: '3.3.3.3'
           };
           async.map(_.range(10), (i, done) => {
             testParams.take(takeParams, done);
           }, (err, responses) => {
             if (err) return done(err);
-            assert.ok(responses.every((r) => { return r.conformant; }));
+            assert.ok(responses.every((r) => {
+              return r.conformant;
+            }));
             testParams.take(takeParams, (err, response) => {
               assert.notOk(response.conformant);
               assert.equal(response.remaining, 0);
@@ -322,8 +325,8 @@ describe('LimitDBRedis', () => {
           testParams.init();
           const takeParams = {
             ...testParams.params,
-            type:  'ip',
-            key:   '127.0.0.1'
+            type: 'ip',
+            key: '127.0.0.1'
           };
           async.each(_.range(10), (i, done) => {
             testParams.take(takeParams, done);
@@ -342,8 +345,8 @@ describe('LimitDBRedis', () => {
           testParams.init();
           const takeParams = {
             ...testParams.params,
-            type:  'ip',
-            key:   '192.168.0.1'
+            type: 'ip',
+            key: '192.168.0.1'
           };
           async.each(_.range(10), (i, done) => {
             testParams.take(takeParams, done);
@@ -362,7 +365,7 @@ describe('LimitDBRedis', () => {
           const takeParams = {
             ...testParams.params,
             type: 'ip',
-            key:  '10.0.0.123'
+            key: '10.0.0.123'
           };
           async.each(_.range(10), (i, cb) => {
             testParams.take(takeParams, cb);
@@ -382,7 +385,7 @@ describe('LimitDBRedis', () => {
           const takeParams = {
             ...testParams.params,
             type: 'ip',
-            key:  '10.0.0.124'
+            key: '10.0.0.124'
           };
           async.each(_.range(10), (i, cb) => {
             testParams.take(takeParams, cb);
@@ -402,11 +405,11 @@ describe('LimitDBRedis', () => {
           // it takes ~1790 msec to fill the bucket with this test
           const now = Date.now();
           const requests = _.range(9).map(() => {
-            return cb => testParams.take({...testParams.params, type: 'ip', key: '211.123.12.36' }, cb);
+            return cb => testParams.take({ ...testParams.params, type: 'ip', key: '211.123.12.36' }, cb);
           });
           async.series(requests, (err, results) => {
             if (err) return done(err);
-            const lastResult = results[results.length -1];
+            const lastResult = results[results.length - 1];
             assert.ok(lastResult.conformant);
             assert.equal(lastResult.remaining, 1);
             assert.closeTo(lastResult.reset, now / 1000, 3);
@@ -418,8 +421,10 @@ describe('LimitDBRedis', () => {
         it(`should set reset to UNIX timestamp regardless of period`, (done) => {
           testParams.init();
           const now = Date.now();
-          testParams.take({...testParams.params, type: 'ip', key: '10.0.0.1' }, (err, result) => {
-            if (err) { return done(err); }
+          testParams.take({ ...testParams.params, type: 'ip', key: '10.0.0.1' }, (err, result) => {
+            if (err) {
+              return done(err);
+            }
             assert.ok(result.conformant);
             assert.equal(result.remaining, 0);
             assert.closeTo(result.reset, now / 1000 + 1800, 1);
@@ -431,7 +436,7 @@ describe('LimitDBRedis', () => {
         it(`should work for unlimited`, (done) => {
           testParams.init();
           const now = Date.now();
-          testParams.take({...testParams.params, type: 'ip', key: '0.0.0.0' }, (err, response) => {
+          testParams.take({ ...testParams.params, type: 'ip', key: '0.0.0.0' }, (err, response) => {
             if (err) return done(err);
             assert.ok(response.conformant);
             assert.equal(response.remaining, 100);
@@ -444,14 +449,14 @@ describe('LimitDBRedis', () => {
         it(`should work with a fixed bucket`, (done) => {
           testParams.init();
           async.map(_.range(10), (i, done) => {
-            testParams.take({...testParams.params, type: 'ip', key: '8.8.8.8' }, done);
+            testParams.take({ ...testParams.params, type: 'ip', key: '8.8.8.8' }, done);
           }, (err, results) => {
             if (err) return done(err);
             results.forEach((r, i) => {
               assert.equal(r.remaining + i + 1, 10);
             });
             assert.ok(results.every(r => r.conformant));
-            testParams.take({...testParams.params, type: 'ip', key: '8.8.8.8' }, (err, response) => {
+            testParams.take({ ...testParams.params, type: 'ip', key: '8.8.8.8' }, (err, response) => {
               assert.notOk(response.conformant);
               done();
             });
@@ -460,7 +465,7 @@ describe('LimitDBRedis', () => {
 
         it(`should work with RegExp`, (done) => {
           testParams.init();
-          testParams.take({...testParams.params, type: 'user', key: 'regexp|test'}, (err, response) => {
+          testParams.take({ ...testParams.params, type: 'user', key: 'regexp|test' }, (err, response) => {
             if (err) {
               return done(err);
             }
@@ -473,7 +478,7 @@ describe('LimitDBRedis', () => {
 
         it(`should work with "all"`, (done) => {
           testParams.init();
-          testParams.take({...testParams.params, type: 'user', key: 'regexp|test', count: 'all'}, (err, response) => {
+          testParams.take({ ...testParams.params, type: 'user', key: 'regexp|test', count: 'all' }, (err, response) => {
             if (err) {
               return done(err);
             }
@@ -486,7 +491,7 @@ describe('LimitDBRedis', () => {
 
         it(`should work with count=0`, (done) => {
           testParams.init();
-          testParams.take({...testParams.params, type: 'ip', key: '9.8.7.6', count: 0 }, (err, response) => {
+          testParams.take({ ...testParams.params, type: 'ip', key: '9.8.7.6', count: 0 }, (err, response) => {
             if (err) {
               return done(err);
             }
@@ -514,14 +519,15 @@ describe('LimitDBRedis', () => {
               count,
             };
 
-            assert.throws(() => testParams.take(opts, () => {}), /if provided, count must be 'all' or an integer value/);
+            assert.throws(() => testParams.take(opts, () => {
+            }), /if provided, count must be 'all' or an integer value/);
             done();
           });
         });
 
         it(`should call redis and not set local cache count`, (done) => {
           testParams.init();
-          const params = {...testParams.params, type: 'global',  key: 'aTenant'};
+          const params = { ...testParams.params, type: 'global', key: 'aTenant' };
           testParams.take(params, (err) => {
             if (err) {
               return done(err);
@@ -535,7 +541,7 @@ describe('LimitDBRedis', () => {
         describe(`${testParams.name} skip calls`, () => {
           it('should skip calls', (done) => {
             testParams.init();
-            const params = {...testParams.params, type: 'global',  key: 'skipit'};
+            const params = { ...testParams.params, type: 'global', key: 'skipit' };
 
             async.series([
               (cb) => testParams.take(params, cb), // redis
@@ -561,31 +567,34 @@ describe('LimitDBRedis', () => {
               }
 
               done();
-            })
+            });
           });
 
           it('should take correct number of tokens for skipped calls with single count', (done) => {
             testParams.init();
-            const params = {...testParams.params, type: 'global',  key: 'skipOneSize3'};
+            const params = { ...testParams.params, type: 'global', key: 'skipOneSize3' };
 
             // size = 3
             // skip_n_calls = 1
             // no refill
             async.series([
-              (cb) => db.get(params, (_, {remaining}) => { assert.equal(remaining, 3); cb(); }),
+              (cb) => db.get(params, (_, { remaining }) => {
+                assert.equal(remaining, 3);
+                cb();
+              }),
 
               // call 1 - redis
               // takes 1 token
               (cb) => testParams.take(params, (_, { remaining, conformant }) => {
                 assert.equal(remaining, 2);
-                assert.ok(conformant)
+                assert.ok(conformant);
                 cb();
               }),
 
               // call 2 - skipped
               (cb) => testParams.take(params, (_, { remaining, conformant }) => {
                 assert.equal(remaining, 2);
-                assert.ok(conformant)
+                assert.ok(conformant);
                 cb();
               }),
 
@@ -593,7 +602,7 @@ describe('LimitDBRedis', () => {
               // takes 2 tokens here, 1 for current call and one for previously skipped call
               (cb) => testParams.take(params, (_, { remaining, conformant }) => {
                 assert.equal(remaining, 0);
-                assert.ok(conformant)
+                assert.ok(conformant);
                 cb();
               }),
 
@@ -617,31 +626,34 @@ describe('LimitDBRedis', () => {
                 return done(err);
               }
               done();
-            })
+            });
           });
 
           it('should take correct number of tokens for skipped calls with multi count', (done) => {
             testParams.init();
-            const params = {...testParams.params, type: 'global',  key: 'skipOneSize10', count: 2};
+            const params = { ...testParams.params, type: 'global', key: 'skipOneSize10', count: 2 };
 
             // size = 10
             // skip_n_calls = 1
             // no refill
             async.series([
-              (cb) => db.get(params, (_, {remaining}) => { assert.equal(remaining, 10); cb(); }),
+              (cb) => db.get(params, (_, { remaining }) => {
+                assert.equal(remaining, 10);
+                cb();
+              }),
 
               // call 1 - redis
               // takes 2 tokens
               (cb) => testParams.take(params, (_, { remaining, conformant }) => {
                 assert.equal(remaining, 8);
-                assert.ok(conformant)
+                assert.ok(conformant);
                 cb();
               }),
 
               // call 2 - skipped
               (cb) => testParams.take(params, (_, { remaining, conformant }) => {
                 assert.equal(remaining, 8);
-                assert.ok(conformant)
+                assert.ok(conformant);
                 cb();
               }),
 
@@ -649,7 +661,7 @@ describe('LimitDBRedis', () => {
               // takes 4 tokens here, 2 for current call and 2 for previously skipped call
               (cb) => testParams.take(params, (_, { remaining, conformant }) => {
                 assert.equal(remaining, 4);
-                assert.ok(conformant)
+                assert.ok(conformant);
                 cb();
               }),
             ], (err, _results) => {
@@ -657,15 +669,15 @@ describe('LimitDBRedis', () => {
                 return done(err);
               }
               done();
-            })
+            });
           });
-        })
-      })
-    })
+        });
+      });
+    });
 
     it('should use size config override when provided', (done) => {
-      const configOverride = { size : 7 };
-      db.take({type: 'ip', key: '7.7.7.7', configOverride}, (err, response) => {
+      const configOverride = { size: 7 };
+      db.take({ type: 'ip', key: '7.7.7.7', configOverride }, (err, response) => {
         if (err) {
           return done(err);
         }
@@ -679,7 +691,7 @@ describe('LimitDBRedis', () => {
     it('should use per interval config override when provided', (done) => {
       const oneDayInMs = ms('24h');
       const configOverride = { per_day: 1 };
-      db.take({type: 'ip', key: '7.7.7.8', configOverride}, (err, response) => {
+      db.take({ type: 'ip', key: '7.7.7.8', configOverride }, (err, response) => {
         if (err) {
           return done(err);
         }
@@ -692,7 +704,7 @@ describe('LimitDBRedis', () => {
     it('should use size AND interval config override when provided', (done) => {
       const oneDayInMs = ms('24h');
       const configOverride = { size: 3, per_day: 1 };
-      db.take({type: 'ip', key: '7.7.7.8', configOverride}, (err, response) => {
+      db.take({ type: 'ip', key: '7.7.7.8', configOverride }, (err, response) => {
         if (err) {
           return done(err);
         }
@@ -708,7 +720,7 @@ describe('LimitDBRedis', () => {
 
     it('should set ttl to reflect config override', (done) => {
       const configOverride = { per_day: 5 };
-      const params = {type: 'ip', key: '7.7.7.9', configOverride};
+      const params = { type: 'ip', key: '7.7.7.9', configOverride };
       db.take(params, (err) => {
         if (err) {
           return done(err);
@@ -724,7 +736,7 @@ describe('LimitDBRedis', () => {
     });
 
     it('should work with no overrides', (done) => {
-      const takeParams = {type: 'tenant', key: 'foo'};
+      const takeParams = { type: 'tenant', key: 'foo' };
       db.take(takeParams, (err, response) => {
         assert.ok(response.conformant);
         assert.equal(response.remaining, 0);
@@ -742,12 +754,14 @@ describe('LimitDBRedis', () => {
       }
       db.configurateBuckets(big);
 
-      const takeParams = {type: 'ip', key: '172.16.1.1'};
+      const takeParams = { type: 'ip', key: '172.16.1.1' };
       async.map(_.range(10), (i, done) => {
         db.take(takeParams, done);
       }, (err, responses) => {
         if (err) return done(err);
-        assert.ok(responses.every((r) => { return r.conformant; }));
+        assert.ok(responses.every((r) => {
+          return r.conformant;
+        }));
         db.take(takeParams, (err, response) => {
           assert.notOk(response.conformant);
           assert.equal(response.remaining, 0);
@@ -839,20 +853,20 @@ describe('LimitDBRedis', () => {
           key: 'some_key',
           erlIsActiveKey: erlIsActiveKey,
           allowERL: true,
-          erlQuota: {key: 'erlquotakey', per_cal_month: 10}
+          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
         };
 
         // erl not activated yet
-        await takeElevatedPromise(params)
-        await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 0))
+        await takeElevatedPromise(params);
+        await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 0));
 
         // erl now activated
-        await takeElevatedPromise(params)
-        await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 1))
+        await takeElevatedPromise(params);
+        await redisExistsPromise(erlIsActiveKey).then((isActive) => assert.equal(isActive, 1));
       });
       it('should raise an error if erlIsActiveKey is not provided for a bucket with elevated_limits configuration', (done) => {
         const bucketName = 'bucket_with_elevated_limits_config';
-        const params = {type: bucketName, key: 'some_bucket_key', erlIsActiveKey: undefined, allowERL:true};
+        const params = { type: bucketName, key: 'some_bucket_key', erlIsActiveKey: undefined, allowERL: true };
         db.configurateBucket(bucketName, {
           size: 1,
           per_minute: 1,
@@ -860,7 +874,7 @@ describe('LimitDBRedis', () => {
             size: 2,
             per_minute: 2,
           },
-        })
+        });
 
         db.takeElevated(params, (err) => {
           assert.match(err.message, /erlIsActiveKey is required for elevated limits/);
@@ -876,25 +890,25 @@ describe('LimitDBRedis', () => {
             size: 10,
             per_minute: 2,
           },
-        })
+        });
         const params = {
           type: bucketName,
           key: 'some_bucket_key',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: {key: 'erlquotakey', per_cal_month: 10}
-        }
+          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
+        };
 
         // first call, still within normal rate limits
         await takeElevatedPromise(params).then((result) => {
           assert.isFalse(result.erl_activated);
-        })
+        });
         // second call, normal rate limits exceeded and erl is activated
         await takeElevatedPromise(params).then((result) => {
           assert.isTrue(result.erl_activated);
           assert.isTrue(result.conformant);
-          assert.equal(result.remaining, 8)
-        })
+          assert.equal(result.remaining, 8);
+        });
 
       });
       it('should rate limit if both normal and erl rate limit are exceeded', async () => {
@@ -904,7 +918,7 @@ describe('LimitDBRedis', () => {
           key: 'some_bucket_key',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: {key: 'erlquotakey', per_cal_month: 10}
+          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -913,27 +927,27 @@ describe('LimitDBRedis', () => {
             size: 2,
             per_minute: 2,
           },
-        })
+        });
 
         // first call, still within normal rate limits
         await takeElevatedPromise(params).then((result) => {
           assert.isTrue(result.conformant);
           assert.isFalse(result.erl_activated);
-          assert.equal(result.remaining, 0)
-        })
+          assert.equal(result.remaining, 0);
+        });
         // second call, normal rate limits exceeded and erl is activated.
         // tokens in bucket is going to be 0 after this call (size 2 - 2 calls)
         await takeElevatedPromise(params).then((result) => {
           assert.isTrue(result.conformant);
           assert.isTrue(result.erl_activated);
           assert.equal(result.remaining, 0);
-        })
+        });
         // third call, erl rate limit exceeded
         await takeElevatedPromise(params).then((result) => {
           assert.isFalse(result.conformant); // being rate limited
           assert.isTrue(result.erl_activated);
           assert.equal(result.remaining, 0);
-        })
+        });
       });
       it('should deduct already used tokens from new bucket when erl is activated', async () => {
         const bucketName = 'test-bucket';
@@ -942,7 +956,7 @@ describe('LimitDBRedis', () => {
           key: 'some_key ',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: {key: 'erlquotakey', per_cal_month: 10}
+          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
         };
         await db.configurateBucket(bucketName, {
           size: 2,
@@ -953,14 +967,14 @@ describe('LimitDBRedis', () => {
           }
         });
 
-        await takeElevatedPromise(params)
-        await takeElevatedPromise(params)
+        await takeElevatedPromise(params);
+        await takeElevatedPromise(params);
         await takeElevatedPromise(params).then((result) => {
           assert.isTrue(result.conformant);
           assert.isTrue(result.erl_activated);
           assert.equal(result.remaining, 7); // Total used tokens so far: 3
         });
-      })
+      });
       it('should use default ttl if erl activation period is not configured', (done) => {
         const bucketName = 'test-bucket';
         const params = {
@@ -968,7 +982,7 @@ describe('LimitDBRedis', () => {
           key: 'some_key',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: {key: 'erlquotakey', per_cal_month: 10}
+          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -979,11 +993,11 @@ describe('LimitDBRedis', () => {
           }
         });
         takeElevatedPromise(params)
-            .then(() => takeElevatedPromise(params))
-            .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
-              assert.equal(ttl, ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS); // 15 minutes in seconds
-              done()
-            }))
+          .then(() => takeElevatedPromise(params))
+          .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
+            assert.equal(ttl, ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS); // 15 minutes in seconds
+            done();
+          }));
       });
       it('should use ttl calculated using erl activation period if erl activation period is configured', (done) => {
         const bucketName = 'test-bucket';
@@ -992,7 +1006,7 @@ describe('LimitDBRedis', () => {
           key: 'some_key',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: {key: 'erlquotakey', per_cal_month: 10}
+          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1004,11 +1018,11 @@ describe('LimitDBRedis', () => {
           }
         });
         takeElevatedPromise(params)
-            .then(() => takeElevatedPromise(params))
-            .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
-              assert.equal(ttl, 1200); // 20 minutes in seconds
-              done()
-            }))
+          .then(() => takeElevatedPromise(params))
+          .then(() => db.redis.ttl('some_erl_active_identifier', (err, ttl) => {
+            assert.equal(ttl, 1200); // 20 minutes in seconds
+            done();
+          }));
       });
       it('should refill with erl refill rate when erl is active', (done) => {
         const bucketName = 'test-bucket';
@@ -1017,7 +1031,7 @@ describe('LimitDBRedis', () => {
           key: 'some_key ',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: {key: 'erlquotakey', per_cal_month: 10}
+          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
         };
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1029,15 +1043,15 @@ describe('LimitDBRedis', () => {
           }
         });
         takeElevatedPromise(params)
-            .then(() => takeElevatedPromise(params)) // erl activated
-            .then(() => new Promise((resolve) => setTimeout(resolve, 10))) // wait for 10ms
-            .then(() => takeElevatedPromise(params)) // refill with erl refill rate
-            .then((result) => {
-              assert.isTrue(result.conformant);
-              assert.isTrue(result.erl_activated);
-              assert.equal(result.remaining, 3);
-              done();
-            })
+          .then(() => takeElevatedPromise(params)) // erl activated
+          .then(() => new Promise((resolve) => setTimeout(resolve, 10))) // wait for 10ms
+          .then(() => takeElevatedPromise(params)) // refill with erl refill rate
+          .then((result) => {
+            assert.isTrue(result.conformant);
+            assert.isTrue(result.erl_activated);
+            assert.equal(result.remaining, 3);
+            done();
+          });
       });
       it('should go back to standard bucket size and refill rate when we stop using takeElevated', (done) => {
         const bucketName = 'test-bucket';
@@ -1046,51 +1060,51 @@ describe('LimitDBRedis', () => {
           key: 'some_key',
           erlIsActiveKey: 'some_erl_active_identifier',
           allowERL: true,
-          erlQuota: {key: 'erlquotakey', per_cal_month: 10}
+          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
         };
         db.configurateBucket(bucketName, {
-            size: 1,
+          size: 1,
+          per_interval: 1,
+          interval: 2,
+          elevated_limits: {
+            size: 5,
             per_interval: 1,
-            interval: 2,
-            elevated_limits: {
-                size: 5,
-                per_interval: 1,
-                interval: 5,
-            }
+            interval: 5,
+          }
         });
 
         // first call to take a token
         takeElevatedPromise(params)
-            // second call. erl activated and token taken. tokens in bucket: 3
-            .then(() => takeElevatedPromise(params))
-            // wait for 5ms, refill 1 token while erl active. tokens in bucket: 4
-            .then(() => new Promise((resolve) => setTimeout(resolve, 5)))
-            // take 1 token. tokens in bucket: 3
-            .then(() => takeElevatedPromise(params))
-            .then((result) => {
-              assert.isTrue(result.conformant);
-              assert.isTrue(result.erl_activated);
-              assert.equal(result.remaining, 3);
-            })
-            // disable ERL, go back to standard bucket size and refill rate
-            // tokens in bucket: 1 (= bucket size)
-            // take 1 token. tokens in bucket: 0
-            .then(() => takePromise(params))
-            .then((result) => {
-                assert.isTrue(result.conformant);
-                assert.notExists(result.erl_activated);
-                assert.equal(result.remaining, 0);
-            })
-            // wait for 2ms, refill 1 token while erl inactive. tokens in bucket: 1
-            .then(() => new Promise((resolve) => setTimeout(resolve, 2)))
-            // take 1 token. tokens in bucket: 0
-            .then(() => takePromise(params))
-            .then((result) => {
-              assert.isTrue(result.conformant);
-              assert.notExists(result.erl_activated);
-              assert.equal(result.remaining, 0);
-              done();
-            })
+          // second call. erl activated and token taken. tokens in bucket: 3
+          .then(() => takeElevatedPromise(params))
+          // wait for 5ms, refill 1 token while erl active. tokens in bucket: 4
+          .then(() => new Promise((resolve) => setTimeout(resolve, 5)))
+          // take 1 token. tokens in bucket: 3
+          .then(() => takeElevatedPromise(params))
+          .then((result) => {
+            assert.isTrue(result.conformant);
+            assert.isTrue(result.erl_activated);
+            assert.equal(result.remaining, 3);
+          })
+          // disable ERL, go back to standard bucket size and refill rate
+          // tokens in bucket: 1 (= bucket size)
+          // take 1 token. tokens in bucket: 0
+          .then(() => takePromise(params))
+          .then((result) => {
+            assert.isTrue(result.conformant);
+            assert.notExists(result.erl_activated);
+            assert.equal(result.remaining, 0);
+          })
+          // wait for 2ms, refill 1 token while erl inactive. tokens in bucket: 1
+          .then(() => new Promise((resolve) => setTimeout(resolve, 2)))
+          // take 1 token. tokens in bucket: 0
+          .then(() => takePromise(params))
+          .then((result) => {
+            assert.isTrue(result.conformant);
+            assert.notExists(result.erl_activated);
+            assert.equal(result.remaining, 0);
+            done();
+          });
       });
 
       it('should return an error when attempting to takeElevated with no elevate config', (done) => {
@@ -1105,13 +1119,13 @@ describe('LimitDBRedis', () => {
           key: 'some_key',
           erlIsActiveKey: erlIsActiveKey,
           allowERL: true,
-          erlQuota: {key: 'erlquotakey', per_cal_month: 10}
+          erlQuota: { key: 'erlquotakey', per_cal_month: 10 }
         };
         db.takeElevated(params, (err) => {
           assert.match(err.message, /Attempted to takeElevated\(\) for a bucket with no elevated config/);
           done();
         });
-      })
+      });
 
       describe('overrides', () => {
         it('should use elevated_limits config override when provided', (done) => {
@@ -1120,35 +1134,35 @@ describe('LimitDBRedis', () => {
           db.configurateBucket(bucketName, {
             size: 1,
             per_minute: 1
-          })
-          const configOverride = { size: 1, elevated_limits: {size: 3, per_second: 3} };
+          });
+          const configOverride = { size: 1, elevated_limits: { size: 3, per_second: 3 } };
           const params = {
             type: bucketName,
             key: 'some_key',
             erlIsActiveKey: erlIsActiveKey,
-            erlQuota: {key: 'erlquotakey', per_cal_month: 10},
+            erlQuota: { key: 'erlquotakey', per_cal_month: 10 },
             configOverride
           };
           takeElevatedPromise(params)
             .then((result) => {
-              assert.isTrue(result.conformant)
-              assert.isFalse(result.erl_activated)
+              assert.isTrue(result.conformant);
+              assert.isFalse(result.erl_activated);
             })
             .then(() => takeElevatedPromise(params))
             .then(() => takeElevatedPromise(params))
             .then((result) => {
-              assert.isTrue(result.conformant)
-              assert.isTrue(result.erl_activated)
-              assert.equal(result.remaining, 0)
+              assert.isTrue(result.conformant);
+              assert.isTrue(result.erl_activated);
+              assert.equal(result.remaining, 0);
             })
             .then(() => takeElevatedPromise(params))
             .then((result) => {
-              assert.isFalse(result.conformant)
+              assert.isFalse(result.conformant);
               db.redis.ttl(erlIsActiveKey, (err, ttl) => {
                 assert.equal(ttl, ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS); // uses default activation period
-                done()
-              })
-            })
+                done();
+              });
+            });
         });
         it('should use erl_activation_period from elevated_limits config override when provided', (done) => {
           const bucketName = 'bucket_with_no_elevated_limits_config';
@@ -1160,24 +1174,24 @@ describe('LimitDBRedis', () => {
           });
           const configOverride = {
             size: 1,
-            elevated_limits: {size: 3, per_second: 3, erl_activation_period_seconds: 60}
+            elevated_limits: { size: 3, per_second: 3, erl_activation_period_seconds: 60 }
           };
           const params = {
             type: bucketName,
             key: 'some_key',
             erlIsActiveKey: erlIsActiveKey,
-            erlQuota: {key: 'erlquotakey', per_cal_month: 10},
+            erlQuota: { key: 'erlquotakey', per_cal_month: 10 },
             configOverride
           };
           takeElevatedPromise(params)
             .then((result) => {
-              assert.isTrue(result.conformant)
-              assert.isFalse(result.erl_activated)
+              assert.isTrue(result.conformant);
+              assert.isFalse(result.erl_activated);
             })
             .then(() => takeElevatedPromise(params))
             .then((result) => {
-              assert.isTrue(result.conformant)
-              assert.isTrue(result.erl_activated)
+              assert.isTrue(result.conformant);
+              assert.isTrue(result.erl_activated);
               db.redis.ttl(erlIsActiveKey, (err, ttl) => {
                 assert.equal(ttl, 60); // uses specified activation period
                 done();
@@ -1215,7 +1229,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should set ttl accordingly on erlQuotaKey when we activate ERL', (done) => {
-          params.erlQuota = {key: 'erlquotakey', per_cal_month: 10};
+          params.erlQuota = { key: 'erlquotakey', per_cal_month: 10 };
 
           const eom = endOfMonthTimestamp();
           // get ms between now and eom
@@ -1245,7 +1259,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should keep ttl on erlQuotaKey after decreasing it', (done) => {
-          params.erlQuota = {key: 'erlquotakey', per_cal_month: 10};
+          params.erlQuota = { key: 'erlquotakey', per_cal_month: 10 };
           let expectedTTL = 0;
 
           // check erl not activated yet
@@ -1284,7 +1298,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should decrease erlQuota when we activate ERL', (done) => {
-          params.erlQuota = {key: 'erlquotakey', per_cal_month: 10};
+          params.erlQuota = { key: 'erlquotakey', per_cal_month: 10 };
 
           // check erl not activated yet
           redisExistsPromise(erlIsActiveKey)
@@ -1307,7 +1321,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should not activate ERL when erlQuota is 0', (done) => {
-          params.erlQuota = {key: 'erlquotakey', per_cal_month: 0};
+          params.erlQuota = { key: 'erlquotakey', per_cal_month: 0 };
 
           // check erl not activated yet
           redisExistsPromise(erlIsActiveKey)
@@ -1332,7 +1346,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should activate ERL when erlQuota is 1', (done) => {
-          params.erlQuota = {key: 'erlquotakey', per_cal_month: 1};
+          params.erlQuota = { key: 'erlquotakey', per_cal_month: 1 };
 
           // check erl not activated yet
           redisExistsPromise(erlIsActiveKey)
@@ -1357,7 +1371,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should not activate ERL if erlQuotaKey exists and is 0', (done) => {
-          params.erlQuota = {key: 'erlquotakey', per_cal_month: 10};
+          params.erlQuota = { key: 'erlquotakey', per_cal_month: 10 };
 
           // set erlQuotaKey to 0 in redis
           redisSetPromise(params.erlQuota.key, 0)
@@ -1383,7 +1397,7 @@ describe('LimitDBRedis', () => {
         });
 
         it('should activate ERL after erlQuotaKey=0 expires', (done) => {
-          params.erlQuota = {key: 'erlquotakey', per_cal_month: 10};
+          params.erlQuota = { key: 'erlquotakey', per_cal_month: 10 };
 
           // set erlQuotaKey to 0 in redis
           redisSetWithExpirePromise(params.erlQuota.key, 0, 1)
@@ -1486,7 +1500,7 @@ describe('LimitDBRedis', () => {
     });
 
     it('should not override on unlimited buckets', (done) => {
-      const bucketKey = { type: 'ip',  key: '0.0.0.0', count: 1000 };
+      const bucketKey = { type: 'ip', key: '0.0.0.0', count: 1000 };
       db.put(bucketKey, (err, result) => {
         if (err) {
           return done(err);
@@ -1497,7 +1511,7 @@ describe('LimitDBRedis', () => {
     });
 
     it('should restore the bucket when reseting', (done) => {
-      const bucketKey = { type: 'ip',  key: '211.123.12.12' };
+      const bucketKey = { type: 'ip', key: '211.123.12.12' };
       db.take(Object.assign({ count: 'all' }, bucketKey), (err) => {
         if (err) return done(err);
         db.put(bucketKey, (err) => {
@@ -1512,7 +1526,7 @@ describe('LimitDBRedis', () => {
     });
 
     it('should restore the bucket when reseting with all', (done) => {
-      const takeParams = { type: 'ip',  key: '21.17.65.41', count: 9 };
+      const takeParams = { type: 'ip', key: '21.17.65.41', count: 9 };
       db.take(takeParams, (err) => {
         if (err) return done(err);
         db.put({ type: 'ip', key: '21.17.65.41', count: 'all' }, (err) => {
@@ -1528,11 +1542,11 @@ describe('LimitDBRedis', () => {
     });
 
     it('should restore nothing when count=0', (done) => {
-      db.take({ type: 'ip',  key: '9.8.7.6', count: 123 }, (err) => {
+      db.take({ type: 'ip', key: '9.8.7.6', count: 123 }, (err) => {
         if (err) return done(err);
         db.put({ type: 'ip', key: '9.8.7.6', count: 0 }, (err) => {
           if (err) return done(err);
-          db.take({ type: 'ip',  key: '9.8.7.6', count: 0 }, (err, response) => {
+          db.take({ type: 'ip', key: '9.8.7.6', count: 0 }, (err, response) => {
             if (err) return done(err);
             assert.equal(response.conformant, true);
             assert.equal(response.remaining, 77);
@@ -1557,13 +1571,14 @@ describe('LimitDBRedis', () => {
           count,
         };
 
-        assert.throws(() => db.put(opts, () => {}), /if provided, count must be 'all' or an integer value/);
+        assert.throws(() => db.put(opts, () => {
+        }), /if provided, count must be 'all' or an integer value/);
         done();
       });
     });
 
     it('should be able to reset without callback', (done) => {
-      const bucketKey = { type: 'ip',  key: '211.123.12.12'};
+      const bucketKey = { type: 'ip', key: '211.123.12.12' };
       db.take(bucketKey, (err) => {
         if (err) return done(err);
         db.put(bucketKey);
@@ -1608,7 +1623,7 @@ describe('LimitDBRedis', () => {
 
     it('should use size config override when provided', (done) => {
       const configOverride = { size: 4 };
-      const bucketKey = { type: 'ip',  key: '7.7.7.9', configOverride };
+      const bucketKey = { type: 'ip', key: '7.7.7.9', configOverride };
       db.take(Object.assign({ count: 'all' }, bucketKey), (err) => {
         if (err) return done(err);
         db.put(bucketKey, (err) => { // restores all 4
@@ -1625,7 +1640,7 @@ describe('LimitDBRedis', () => {
     it('should use per interval config override when provided', (done) => {
       const oneDayInMs = ms('24h');
       const configOverride = { per_day: 1 };
-      const bucketKey = { type: 'ip',  key: '7.7.7.10', configOverride };
+      const bucketKey = { type: 'ip', key: '7.7.7.10', configOverride };
       db.take(Object.assign({ count: 'all' }, bucketKey), (err) => {
         if (err) return done(err);
         db.put(bucketKey, (err) => { // restores all 4
@@ -1643,7 +1658,7 @@ describe('LimitDBRedis', () => {
     it('should use size AND per interval config override when provided', (done) => {
       const oneDayInMs = ms('24h');
       const configOverride = { size: 4, per_day: 1 };
-      const bucketKey = { type: 'ip',  key: '7.7.7.11', configOverride };
+      const bucketKey = { type: 'ip', key: '7.7.7.11', configOverride };
       db.take(Object.assign({ count: 'all' }, bucketKey), (err) => {
         if (err) return done(err);
         db.put(bucketKey, (err) => { // restores all 4
@@ -1661,7 +1676,7 @@ describe('LimitDBRedis', () => {
 
     it('should set ttl to reflect config override', (done) => {
       const configOverride = { per_day: 5 };
-      const bucketKey = { type: 'ip', key: '7.7.7.12', configOverride};
+      const bucketKey = { type: 'ip', key: '7.7.7.12', configOverride };
       db.take(Object.assign({ count: 'all' }, bucketKey), (err) => {
         if (err) return done(err);
         db.put(bucketKey, (err) => { // restores all 4
@@ -1690,7 +1705,7 @@ describe('LimitDBRedis', () => {
     });
 
     it('should return the bucket default for remaining when key does not exist', (done) => {
-      db.get({type: 'ip', key: '8.8.8.8'}, (err, result) => {
+      db.get({ type: 'ip', key: '8.8.8.8' }, (err, result) => {
         if (err) {
           return done(err);
         }
@@ -1704,13 +1719,13 @@ describe('LimitDBRedis', () => {
         if (err) {
           return done(err);
         }
-        db.get({type: 'ip', key: '8.8.8.8'}, (err, result) => {
+        db.get({ type: 'ip', key: '8.8.8.8' }, (err, result) => {
           if (err) {
             return done(err);
           }
           assert.equal(result.remaining, 9);
 
-          db.get({type: 'ip', key: '8.8.8.8'}, (err, result) => {
+          db.get({ type: 'ip', key: '8.8.8.8' }, (err, result) => {
             if (err) {
               return done(err);
             }
@@ -1722,7 +1737,7 @@ describe('LimitDBRedis', () => {
     });
 
     it('should return the bucket for an unlimited key', (done) => {
-      db.get({type: 'ip', key: '0.0.0.0'}, (err, result) => {
+      db.get({ type: 'ip', key: '0.0.0.0' }, (err, result) => {
         if (err) {
           return done(err);
         }
@@ -1732,7 +1747,7 @@ describe('LimitDBRedis', () => {
           if (err) {
             return done(err);
           }
-          db.get({type: 'ip', key: '0.0.0.0'}, (err, result) => {
+          db.get({ type: 'ip', key: '0.0.0.0' }, (err, result) => {
             if (err) {
               return done(err);
             }
@@ -1747,7 +1762,7 @@ describe('LimitDBRedis', () => {
 
     it('should use size config override when provided', (done) => {
       const configOverride = { size: 7 };
-      db.get({type: 'ip', key: '7.7.7.13', configOverride}, (err, result) => {
+      db.get({ type: 'ip', key: '7.7.7.13', configOverride }, (err, result) => {
         if (err) {
           return done(err);
         }
@@ -1802,7 +1817,9 @@ describe('LimitDBRedis', () => {
           key: '211.76.23.5',
           count: 3
         }, (err, response) => {
-          if (err) { return done(err); }
+          if (err) {
+            return done(err);
+          }
           var waited = Date.now() - waitingSince;
           assert.ok(response.conformant);
           assert.ok(response.delayed);
@@ -1825,7 +1842,9 @@ describe('LimitDBRedis', () => {
           key: '211.76.23.5',
           count: 0
         }, (err, response) => {
-          if (err) { return done(err); }
+          if (err) {
+            return done(err);
+          }
           var waited = Date.now() - waitingSince;
           assert.ok(response.conformant);
           assert.notOk(response.delayed);
@@ -1853,7 +1872,9 @@ describe('LimitDBRedis', () => {
           count: 1,
           configOverride
         }, (err, response) => {
-          if (err) { return done(err); }
+          if (err) {
+            return done(err);
+          }
           var waited = Date.now() - waitingSince;
           assert.ok(response.conformant);
           assert.ok(response.delayed);
@@ -1910,33 +1931,33 @@ describe('LimitDBRedis Ping', () => {
     maxFailedAttempts: 3,
     reconnectIfFailed: () => true,
     maxFailedAttemptsToRetryReconnect: 10
-  }
+  };
 
   let config = {
     uri: 'localhost:22222',
     buckets,
     prefix: 'tests:',
     ping,
-  }
+  };
 
   let redisProxy;
   let toxiproxy;
   let db;
 
   beforeEach((done) => {
-    toxiproxy = new Toxiproxy("http://localhost:8474");
+    toxiproxy = new Toxiproxy('http://localhost:8474');
     proxyBody = {
-      listen: "0.0.0.0:22222",
+      listen: '0.0.0.0:22222',
       name: crypto.randomUUID(), //randomize name to avoid concurrency issues
-      upstream: "redis:6379"
+      upstream: 'redis:6379'
     };
     toxiproxy.createProxy(proxyBody)
-    .then((proxy) => {
-      redisProxy = proxy;
-      done();
-    })
+      .then((proxy) => {
+        redisProxy = proxy;
+        done();
+      });
 
-  })
+  });
 
   afterEach((done) => {
     redisProxy.remove().then(() =>
@@ -1948,10 +1969,10 @@ describe('LimitDBRedis Ping', () => {
         done(err);
       })
     );
-  })
+  });
 
   it('should emit ping success', (done) => {
-    db = createDB({ uri: 'localhost:22222', buckets, prefix: 'tests:', ping }, done)
+    db = createDB({ uri: 'localhost:22222', buckets, prefix: 'tests:', ping }, done);
     db.once(('ping'), (result) => {
       if (result.status === LimitDB.PING_SUCCESS) {
         done();
@@ -1962,7 +1983,7 @@ describe('LimitDBRedis Ping', () => {
   it('should emit "ping - error" when redis stops responding pings', (done) => {
     let called = false;
 
-    db = createDB(config, done)
+    db = createDB(config, done);
     db.once(('ready'), () => addLatencyToxic(redisProxy, 20000, noop));
     db.on(('ping'), (result) => {
       if (result.status === LimitDB.PING_ERROR && !called) {
@@ -1975,12 +1996,12 @@ describe('LimitDBRedis Ping', () => {
 
   it('should emit "ping - reconnect" when redis stops responding pings and client is configured to reconnect', (done) => {
     let called = false;
-    db = createDB(config, done)
+    db = createDB(config, done);
     db.once(('ready'), () => addLatencyToxic(redisProxy, 20000, noop));
     db.on(('ping'), (result) => {
       if (result.status === LimitDB.PING_RECONNECT && !called) {
         called = true;
-        db.removeAllListeners('ping')
+        db.removeAllListeners('ping');
         done();
       }
     });
@@ -1988,26 +2009,26 @@ describe('LimitDBRedis Ping', () => {
 
   it('should emit "ping - reconnect dry run" when redis stops responding pings and client is NOT configured to reconnect', (done) => {
     let called = false;
-    db = createDB({ ...config, ping: {...ping, reconnectIfFailed: () => false} }, done)
+    db = createDB({ ...config, ping: { ...ping, reconnectIfFailed: () => false } }, done);
     db.once(('ready'), () => addLatencyToxic(redisProxy, 20000, noop));
     db.on(('ping'), (result) => {
       if (result.status === LimitDB.PING_RECONNECT_DRY_RUN && !called) {
         called = true;
-        db.removeAllListeners('ping')
+        db.removeAllListeners('ping');
         done();
       }
     });
   });
 
   it(`should NOT emit ping events when config.ping is not set`, (done) => {
-    db = createDB({ ...config, ping: undefined }, done)
+    db = createDB({ ...config, ping: undefined }, done);
 
     db.once(('ping'), (result) => {
-      done(new Error(`unexpected ping event emitted ${result}`))
-    })
+      done(new Error(`unexpected ping event emitted ${result}`));
+    });
 
     //If after 100ms there are no interactions, we mark the test as passed.
-    setTimeout(done, 100)
+    setTimeout(done, 100);
   });
 
   it('should recover from a connection loss', (done) => {
@@ -2015,7 +2036,7 @@ describe('LimitDBRedis Ping', () => {
     let reconnected = false;
     let toxic = undefined;
     let timeoutId;
-    db = createDB({ ...config, ping: {...ping, interval: 50} }, done)
+    db = createDB({ ...config, ping: { ...ping, interval: 50 } }, done);
 
     db.on(('ping'), (result) => {
       if (result.status === LimitDB.PING_SUCCESS) {
@@ -2024,22 +2045,22 @@ describe('LimitDBRedis Ping', () => {
           toxic = addLatencyToxic(redisProxy, 20000, (t) => toxic = t);
         } else if (reconnected) {
           clearTimeout(timeoutId);
-          db.removeAllListeners('ping')
+          db.removeAllListeners('ping');
           done();
         }
       } else if (result.status === LimitDB.PING_RECONNECT) {
-        if (pingResponded && !reconnected ) {
+        if (pingResponded && !reconnected) {
           reconnected = true;
           toxic.remove();
         }
       }
-    })
+    });
 
-    timeoutId = setTimeout(() => done(new Error("Not reconnected")), 1800);
+    timeoutId = setTimeout(() => done(new Error('Not reconnected')), 1800);
   });
 
   const createDB = (config, done) => {
-    let tmpDB = new LimitDB(config)
+    let tmpDB = new LimitDB(config);
 
     tmpDB.on(('error'), (err) => {
       //As we actively close the connection, there might be network-related errors while attempting to reconnect
@@ -2048,23 +2069,23 @@ describe('LimitDBRedis Ping', () => {
       }
 
       if (err) {
-        console.log(err, err.message)
-        done(err)
+        console.log(err, err.message);
+        done(err);
       }
-    })
+    });
 
-    return tmpDB
-  }
+    return tmpDB;
+  };
 
   const addLatencyToxic = (proxy, latency, callback) => {
     let toxic = new Toxic(
       proxy,
-      {type: "latency", attributes: { latency: latency }}
-    )
-    proxy.addToxic(toxic).then(callback)
-  }
+      { type: 'latency', attributes: { latency: latency } }
+    );
+    proxy.addToxic(toxic).then(callback);
+  };
 
 
-
-  const noop = () => {}
+  const noop = () => {
+  };
 });

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -1,7 +1,7 @@
 /* eslint-env node, mocha */
 const assert = require('chai').assert;
 
-const { getERLQuotaAmountAndExpiration } = require('../lib/utils');
+const { getERLKeysQuotaAmountAndExpiration } = require('../lib/utils');
 const { set, reset } = require('mockdate');
 
 describe('utils', () => {
@@ -19,15 +19,18 @@ describe('utils', () => {
         set(test.date);
 
         const params = {
-          erlQuota: {
-            key: 'erlQuotaKey', per_calendar_month: 192
+          elevatedLimits: {
+            erlIsActiveKey: 'erlIsActiveKey',
+            erlQuotaKey: 'erlQuotaKey',
+            per_calendar_month: 192
           }
         };
 
-        const result = getERLQuotaAmountAndExpiration(params);
+        const result = getERLKeysQuotaAmountAndExpiration(params.elevatedLimits);
 
-        assert.equal(result.key, params.erlQuota.key);
-        assert.equal(result.amount, params.erlQuota.per_calendar_month);
+        assert.equal(result.erlIsActiveKey, params.elevatedLimits.erlIsActiveKey);
+        assert.equal(result.erlQuotaKey, params.elevatedLimits.erlQuotaKey);
+        assert.equal(result.amount, params.elevatedLimits.per_calendar_month);
         assert.equal(result.expiration, test.expiration);
       });
     });

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -19,18 +19,18 @@ describe('utils', () => {
         set(test.date);
 
         const params = {
-          elevatedLimits: {
-            erlIsActiveKey: 'erlIsActiveKey',
-            erlQuotaKey: 'erlQuotaKey',
+          elevated_limits: {
+            erl_is_active_key: 'erl_is_active_key',
+            erl_quota_key: 'erl_quota_key',
             per_calendar_month: 192
           }
         };
 
-        const result = getERLKeysQuotaAmountAndExpiration(params.elevatedLimits);
+        const result = getERLKeysQuotaAmountAndExpiration(params.elevated_limits);
 
-        assert.equal(result.erlIsActiveKey, params.elevatedLimits.erlIsActiveKey);
-        assert.equal(result.erlQuotaKey, params.elevatedLimits.erlQuotaKey);
-        assert.equal(result.amount, params.elevatedLimits.per_calendar_month);
+        assert.equal(result.erl_is_active_key, params.elevated_limits.erl_is_active_key);
+        assert.equal(result.erl_quota_key, params.elevated_limits.erl_quota_key);
+        assert.equal(result.amount, params.elevated_limits.per_calendar_month);
         assert.equal(result.expiration, test.expiration);
       });
     });

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -15,7 +15,7 @@ describe('utils', () => {
     }];
 
     dateTests.forEach(test => {
-      it(`should return appropriate key, amount., and expiration when there's ${test.name}`, () => {
+      it(`should return appropriate key, amount, and expiration when there's ${test.name}`, () => {
         set(test.date);
 
         const params = {

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -20,14 +20,14 @@ describe('utils', () => {
 
         const params = {
           erlQuota: {
-            key: 'erlQuotaKey', per_cal_month: 192
+            key: 'erlQuotaKey', per_calendar_month: 192
           }
         };
 
         const result = getERLQuotaAmountAndExpiration(params);
 
         assert.equal(result.key, params.erlQuota.key);
-        assert.equal(result.amount, params.erlQuota.per_cal_month);
+        assert.equal(result.amount, params.erlQuota.per_calendar_month);
         assert.equal(result.expiration, test.expiration);
       });
     });

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -1,7 +1,7 @@
 /* eslint-env node, mocha */
 const assert = require('chai').assert;
 
-const { extractERLQuota } = require('../lib/utils');
+const { getERLQuotaAmountAndExpiration } = require('../lib/utils');
 const { set, reset } = require('mockdate');
 
 describe('utils', () => {
@@ -24,7 +24,7 @@ describe('utils', () => {
           }
         };
 
-        const result = extractERLQuota(params);
+        const result = getERLQuotaAmountAndExpiration(params);
 
         assert.equal(result.key, params.erlQuota.key);
         assert.equal(result.amount, params.erlQuota.per_cal_month);

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -1,3 +1,4 @@
+/* eslint-env node, mocha */
 const assert = require('chai').assert;
 
 const { extractERLQuota } = require('../lib/utils');
@@ -5,23 +6,13 @@ const { set, reset } = require('mockdate');
 
 describe('utils', () => {
   describe('extractERLQuota', () => {
-    const dateTests = [
-      {
-        date: '2024-03-15T12:00:00.000Z',
-        expiration: 1711929600000,
-        name: '16 days, 12 hs left to end of month'
-      },
-      {
-        date: '2024-03-31T23:00:00.000Z',
-        expiration: 1711929600000,
-        name: '1 hour left to end of month'
-      },
-      {
-        date: '2024-03-31T23:59:59.000Z',
-        expiration: 1711929600000,
-        name: '1 second left to end of month'
-      }
-    ];
+    const dateTests = [{
+      date: '2024-03-15T12:00:00.000Z', expiration: 1711929600000, name: '16 days, 12 hs left to end of month'
+    }, {
+      date: '2024-03-31T23:00:00.000Z', expiration: 1711929600000, name: '1 hour left to end of month'
+    }, {
+      date: '2024-03-31T23:59:59.000Z', expiration: 1711929600000, name: '1 second left to end of month'
+    }];
 
     dateTests.forEach(test => {
       it(`should return appropriate key, amount., and expiration when there's ${test.name}`, () => {
@@ -29,8 +20,7 @@ describe('utils', () => {
 
         const params = {
           erlQuota: {
-            key: 'erlQuotaKey',
-            per_cal_month: 192
+            key: 'erlQuotaKey', per_cal_month: 192
           }
         };
 

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -1,0 +1,49 @@
+const assert = require('chai').assert;
+
+const { extractERLQuota } = require('../lib/utils');
+const { set, reset } = require('mockdate');
+
+describe('utils', () => {
+  describe('extractERLQuota', () => {
+    const dateTests = [
+      {
+        date: '2024-03-15T12:00:00.000Z',
+        expiration: 1711929600000,
+        name: '16 days, 12 hs left to end of month'
+      },
+      {
+        date: '2024-03-31T23:00:00.000Z',
+        expiration: 1711929600000,
+        name: '1 hour left to end of month'
+      },
+      {
+        date: '2024-03-31T23:59:59.000Z',
+        expiration: 1711929600000,
+        name: '1 second left to end of month'
+      }
+    ];
+
+    dateTests.forEach(test => {
+      it(`should return appropriate key, amount., and expiration when there's ${test.name}`, () => {
+        set(test.date);
+
+        const params = {
+          erlQuota: {
+            key: 'erlQuotaKey',
+            per_cal_month: 192
+          }
+        };
+
+        const result = extractERLQuota(params);
+
+        assert.equal(result.key, params.erlQuota.key);
+        assert.equal(result.amount, params.erlQuota.per_cal_month);
+        assert.equal(result.expiration, test.expiration);
+      });
+    });
+
+    afterEach(() => {
+      reset();
+    });
+  });
+});

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -30,8 +30,8 @@ describe('utils', () => {
 
         assert.equal(result.erl_is_active_key, params.elevated_limits.erl_is_active_key);
         assert.equal(result.erl_quota_key, params.elevated_limits.erl_quota_key);
-        assert.equal(result.amount, params.elevated_limits.per_calendar_month);
-        assert.equal(result.expiration, test.expiration);
+        assert.equal(result.erl_quota_amount, params.elevated_limits.per_calendar_month);
+        assert.equal(result.erl_quota_expiration, test.expiration);
       });
     });
 

--- a/test/validation.tests.js
+++ b/test/validation.tests.js
@@ -1,3 +1,4 @@
+/* eslint-env node, mocha */
 const assert = require('chai').assert;
 
 const { validateParams } = require('../lib/validation');


### PR DESCRIPTION
### Description

This PR includes the Quota Counting mechanism for ERL.

### What is ERL?

ERL is a feature that will allow defining a different set of limits that temporarily kick in when the bucket is empty. The feature aims to provide a way to temporarily allow a higher rate of requests when the bucket is empty, to reduce friction.

> This PR completes the ERL feature that allows setting a quota for how long and how many times ERL can be activated for a given bucket.

Please see changes to README for details on what needs to be provided to enable and use ERL with quota counting.

###  Is the change backwards-compatible?

Yes. You don't have to make any changes to your existing code using limitd-redis.

All the work has been done within the new takeElevated method.

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
