### PR TITLE
Update ioredis v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd-redis",
-  "version": "7.8.1",
+  "version": "8.0.0",
   "description": "A database client for limits on top of redis",
   "main": "index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "async": "^2.6.1",
     "disyuntor": "^3.5.0",
-    "ioredis": "^4.28.5",
+    "ioredis": "^5.3.2",
     "lodash": "^4.17.15",
     "lru-cache": "^4.1.5",
     "ms": "^2.1.2",


### PR DESCRIPTION
Updating `ioredis` to latest version 5.3.2, and updating package version to `8.0.0`. See migration guide here https://github.com/redis/ioredis/wiki/Upgrading-from-v4-to-v5.

No changes needed with this implementation of `ioredis` as we are already configuring `slotsRefreshInterval` by default.


