### PR TITLE
Erl call take if no erl config

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ The result object has:
 -  `elevated_limits` (object)
   -  `triggered` (boolean): true if ERL was triggered in the current request.
   -  `activated` (boolean): true if ERL is activated. Not necessarily triggered in this call.
-  -  `quota_count` (int): **[Only valid if triggered=true]** If `triggered=true`, this value contains the current quota count for the given `erl_quota_key`. Otherwise, it will return -1, which is not valid to be interpreted as a quota count.
+  -  `quota_count` (int): **[Only valid if triggered=true]** If `triggered=true`, this value contains the current quota count left for the given `erl_quota_key`. Otherwise, it will return -1, which is not valid to be interpreted as a quota count.
 
 Example of interpretation:
 ``` javascript

--- a/lib/client.js
+++ b/lib/client.js
@@ -103,6 +103,10 @@ class LimitdRedis extends EventEmitter {
     this.handler('take', type, key, opts, cb);
   }
 
+  takeElevated(type, key, opts, cb) {
+    this.handler('takeElevated', type, key, opts, cb);
+  }
+
   wait(type, key, opts, cb) {
     this.handler('wait', type, key, opts, cb);
   }

--- a/lib/db.js
+++ b/lib/db.js
@@ -289,17 +289,24 @@ class LimitDBRedis extends EventEmitter {
   }
 
   takeElevated(params, callback) {
-    const valError = validateERLParams(params.elevated_limits);
-    if (valError) {
-      return callback(valError)
+    const valERLParamsError = validateERLParams(params.elevated_limits);
+    if (valERLParamsError) {
+      return callback(valERLParamsError)
     }
     const erlParams = utils.getERLKeysQuotaAmountAndExpiration(params.elevated_limits);
 
     this._doTake(params, callback, (key, bucketKeyConfig, count) => {
-      const valError = validateConfigIsForElevatedBucket(key, bucketKeyConfig)
-      if (valError) {
-        return callback(valError)
+      let isERLEnabledForBucket = true;
+      const valERLConfigError = validateConfigIsForElevatedBucket(key, bucketKeyConfig)
+      if (valERLConfigError) {
+        isERLEnabledForBucket = false
+        bucketKeyConfig.elevated_limits = {
+          ms_per_interval: bucketKeyConfig.ms_per_interval,
+          size: bucketKeyConfig.size,
+          erl_activation_period_seconds: 0
+        }
       }
+
       this.redis.takeElevated(key, erlParams.erl_is_active_key, erlParams.erl_quota_key,
         bucketKeyConfig.ms_per_interval || 0,
         bucketKeyConfig.size,
@@ -311,6 +318,7 @@ class LimitDBRedis extends EventEmitter {
         bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
         erlParams.erl_quota_amount,
         erlParams.erl_quota_expiration,
+        isERLEnabledForBucket,
         (err, results) => {
           if (err) {
             return callback(err);

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -8,6 +8,7 @@ local erl_bucket_size = tonumber(ARGV[7])
 local erl_activation_period_seconds = tonumber(ARGV[8])
 local erl_quota_amount = tonumber(ARGV[9])
 local erl_quota_expiration_epoch = tonumber(ARGV[10])
+local is_erl_enabled = ARGV[11] == "true" and true or false
 
 -- the key to use for pulling last bucket state from redis
 local lastBucketStateKey = KEYS[1]
@@ -85,7 +86,7 @@ if enough_tokens then
     end
 else
     -- if tokens are not enough, see if activating erl will help.
-    if is_erl_activated == 0 then
+    if is_erl_activated == 0 and is_erl_enabled then
         local used_tokens = bucket_size - bucket_content_after_refill
         local bucket_content_after_erl_activation = erl_bucket_size - used_tokens
         local enough_tokens_after_erl_activation = bucket_content_after_erl_activation >= tokens_to_take

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -75,7 +75,7 @@ end
 
 local enough_tokens = bucket_content_after_refill >= tokens_to_take
 local bucket_content_after_take = bucket_content_after_refill
-local erl_quota = -1
+local erl_quota_left = -1
 local erl_triggered = false
 
 if enough_tokens then
@@ -91,7 +91,8 @@ else
         local bucket_content_after_erl_activation = erl_bucket_size - used_tokens
         local enough_tokens_after_erl_activation = bucket_content_after_erl_activation >= tokens_to_take
         if enough_tokens_after_erl_activation then
-            erl_quota = takeERLQuota(erl_quota_key, erl_quota_amount, erl_quota_expiration_epoch)
+            local erl_quota = takeERLQuota(erl_quota_key, erl_quota_amount, erl_quota_expiration_epoch)
+            -- erl_quota contains the quota before taking one to avoid confusing erl_quota=0 with the last element of the quota
             if erl_quota > 0 then
                 enough_tokens = enough_tokens_after_erl_activation -- we are returning this value, thus setting it
                 bucket_content_after_take = math.min(bucket_content_after_erl_activation - tokens_to_take, erl_bucket_size)
@@ -99,6 +100,8 @@ else
                 redis.call('SET', erlKey, '1')
                 redis.call('EXPIRE', erlKey, erl_activation_period_seconds)
                 is_erl_activated = 1
+                -- now we remove one from the quota to return what's left in the bucket
+                erl_quota_left = erl_quota - 1
                 erl_triggered = true
             end
         end
@@ -121,4 +124,4 @@ if drip_interval > 0 then
 end
 
 -- Return the current quota
-return { bucket_content_after_take, enough_tokens, current_timestamp_ms, reset_ms, erl_triggered, is_erl_activated, erl_quota }
+return { bucket_content_after_take, enough_tokens, current_timestamp_ms, reset_ms, erl_triggered, is_erl_activated, erl_quota_left }

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -135,6 +135,21 @@ describe('LimitdRedis', () => {
     });
   });
 
+  describe('#takeElevated', () => {
+    it('should call #handle with takeElevated as the method', (done) => {
+      const elevated_limits = { erl_is_active_key: 'erlKEY', erl_quota_key: 'quotaKEY', per_calendar_month: 100 };
+      client.handler = (method, type, key, opts, cb) => {
+        assert.equal(method, 'takeElevated');
+        assert.isNotNull(opts.elevated_limits);
+        assert.equal(opts.elevated_limits.erl_is_active_key, elevated_limits.erl_is_active_key);
+        assert.equal(opts.elevated_limits.erl_quota_key, elevated_limits.erl_quota_key);
+        assert.equal(opts.elevated_limits.per_calendar_month, elevated_limits.per_calendar_month);
+        cb();
+      };
+      client.takeElevated('test', 'test', { elevated_limits: elevated_limits }, done);
+    });
+  });
+
   describe('#wait', () => {
     it('should call #handle with take as the method', (done) => {
       client.handler = (method, type, key, count, cb) => {

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -862,7 +862,7 @@ describe('LimitDBRedis', () => {
         await takeElevatedPromise(params);
         await redisExistsPromise(erl_is_active_key).then((isActive) => assert.equal(isActive, 1));
       });
-      it('should raise an error if elevated_limits object is not provided for a bucket with elevated_limits configuration', (done) => {
+      it('should raise an error if elevated_limits object is not provided when calling takeElevated()', (done) => {
         const bucketName = 'bucket_with_elevated_limits_config';
         const params = { type: bucketName, key: 'some_bucket_key' };
         db.configurateBucket(bucketName, {
@@ -879,7 +879,7 @@ describe('LimitDBRedis', () => {
           done();
         });
       });
-      it('should raise an error if elevated_limits.erl_is_active_key is not provided for a bucket with elevated_limits configuration', (done) => {
+      it('should raise an error if elevated_limits.erl_is_active_key is not provided when calling takeElevated()', (done) => {
         const bucketName = 'bucket_with_elevated_limits_config';
         db.configurateBucket(bucketName, {
           size: 1,
@@ -900,7 +900,7 @@ describe('LimitDBRedis', () => {
           done();
         });
       });
-      it('should raise an error if elevated_limits.erl_quota_key is not provided for a bucket with elevated_limits configuration', (done) => {
+      it('should raise an error if elevated_limits.erl_quota_key is not provided when calling takeElevated()', (done) => {
         const bucketName = 'bucket_with_elevated_limits_config';
         db.configurateBucket(bucketName, {
           size: 1,
@@ -921,7 +921,7 @@ describe('LimitDBRedis', () => {
           done();
         });
       });
-      it('should raise an error if elevated_limits.per_calendar_month is not provided for a bucket with elevated_limits configuration', (done) => {
+      it('should raise an error if elevated_limits.per_calendar_month is not provided when calling takeElevated()', (done) => {
         const bucketName = 'bucket_with_elevated_limits_config';
         db.configurateBucket(bucketName, {
           size: 1,
@@ -1155,7 +1155,7 @@ describe('LimitDBRedis', () => {
           });
       });
 
-      it('should return an error when attempting to takeElevated with no elevate config', (done) => {
+      it('should work if attempted to takeElevated with no elevated config', (done) => {
         const bucketName = 'bucket_with_no_elevated_limits_config';
         const erl_is_active_key = 'some_erl_active_identifier';
         db.configurateBucket(bucketName, {
@@ -1167,10 +1167,27 @@ describe('LimitDBRedis', () => {
           key: 'some_key',
           elevated_limits: { erl_is_active_key: erl_is_active_key, erl_quota_key: 'erlquotakey', per_calendar_month: 10 },
         };
-        db.takeElevated(params, (err) => {
-          assert.match(err.message, /Attempted to takeElevated\(\) for a bucket with no elevated config/);
-          done();
-        });
+        takeElevatedPromise(params)
+          .then((result) => {
+            assert.isTrue(result.conformant);
+            assert.equal(result.remaining, 0);
+            assert.equal(result.limit, 1);
+            assert.isNotNull(result.elevated_limits);
+            assert.isFalse(result.elevated_limits.triggered);
+            assert.isFalse(result.elevated_limits.activated);
+            assert.equal(result.elevated_limits.quota_count, -1);
+          })
+          .then(() => takeElevatedPromise(params))
+          .then((result) => {
+            assert.isFalse(result.conformant);
+            assert.equal(result.remaining, 0);
+            assert.equal(result.limit, 1);
+            assert.isNotNull(result.elevated_limits);
+            assert.isFalse(result.elevated_limits.triggered);
+            assert.isFalse(result.elevated_limits.activated);
+            assert.equal(result.elevated_limits.quota_count, -1);
+          })
+          .then(done)
       });
 
       describe('overrides', () => {


### PR DESCRIPTION
### Description
This PR includes 3 minor fixes:
- If calling `takeElevated` for a bucket with no elevated configuration, it allows the call to takeElevated.lua but indicating ERL is disabled so it doesn't attempt to activate it. It 
- Adding takeElevated to client.js 
- takeElevated now returns the quota left in the bucket after activating ERL instead of the quota previous to activating it, to make it easier for the clients to understand it.

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ x ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ x ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ x ] The correct base branch is being used, if not the default branch
