### PR TITLE
Elevated rate limits incremental quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,14 +200,14 @@ limitd.takeElevated(type, key, { count, configOverride, elevated_limits }, (err,
   - `erl_is_active_key`: (string) the identifier of the ERL activation for the bucket.
   - `erl_quota_key`: (string) the identifier of the ERL quota bucket name.
 
-`erlQuota.per_calendar_month` is the only refill rate available for ERL quota buckets at the moment. 
+`quota_per_calendar_month` is the only refill rate available for ERL quota buckets at the moment. 
 The quota bucket will be used to track the amount of ERL activations that can be done in a calendar month. 
 If the quota bucket is empty, the ERL activation will not be possible. 
 The quota bucket will be refilled at the beginning of every calendar month.
 
-For instance, if you want to allow a user to activate ERL for a bucket only 5 times in a month, you can define a quota bucket with `per_calendar_month: 5`.
+For instance, if you want to allow a user to activate ERL for a bucket only 5 times in a month, you can define a quota bucket with `quota_per_calendar_month: 5`.
 That means that the user can activate ERL for the bucket 5 times in a month, and after that, the ERL activation will not be possible until the start of the next month.
-The total minutes allowed for ERL activation in a calendar month is calculated as follows: `per_calendar_month * erl_activation_period_seconds / 60`.
+The total minutes allowed for ERL activation in a calendar month is calculated as follows: `quota_per_calendar_month * erl_activation_period_seconds / 60`.
 
 The result object has:
 -  `conformant` (boolean): true if the requested amount is conformant to the limit.
@@ -217,7 +217,9 @@ The result object has:
 -  `elevated_limits` (object)
   -  `triggered` (boolean): true if ERL was triggered in the current request.
   -  `activated` (boolean): true if ERL is activated. Not necessarily triggered in this call.
-  -  `quota_count` (int): **[Only valid if triggered=true]** If `triggered=true`, this value contains the current quota count left for the given `erl_quota_key`. Otherwise, it will return -1, which is not valid to be interpreted as a quota count.
+  -  `quota_used` (int): **[Only valid if triggered=true]** If `triggered=true`, this value contains the current quota count for the given `erl_quota_key`. Otherwise, it will return -1, which is not valid to be interpreted as a quota count.
+  -  `quota_allocated`: (int): amount of quota allocated in the bucket configuration. This value is defined in the bucket configuration and is the same as `quota_per_calendar_month`.
+  -  `erl_activation_period_seconds`: (int): the ERL activation period as defined in the bucket configuration used in the current request.
 
 Example of interpretation:
 ``` javascript

--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ To be able to allow its use within limitd-redis, you need to:
 2. pass the `elevated_limits` parameter with the following properties:
    - `erl_is_active_key`: the identifier of the ERL activation for the bucket. This works similarly to the `key` you pass to `limitd.take`, which is the identifier of the bucket; however it's used to track the ERL activation for the bucket instead
    - `erl_quota_key`: the identifier of the ERL quota bucket name.
-   - `per_calendar_month`: the amount of tokens that the quota bucket will receive on every calendar month.
 3. make sure that the bucket definition has ERL configured.
 
 ### Configuration
@@ -141,6 +140,7 @@ buckets = {
       size: 100, // new bucket size. already used tokens will be deducted from current bucket content upon ERL activation.
       per_second: 50, // new bucket refill rate. You can use all the other refill rate configurations defined above, such as per_minute, per_hour, per_interval etc.
       erl_activation_period_seconds: 300, // for how long the ERL configuration should remain active once activated.
+      quota_per_calendar_month: 100, // the amount of ERL activations that can be done in a calendar month. Each activation will remain active during erl_activation_period_seconds. 
     }
   }
 }
@@ -151,8 +151,7 @@ ERL quota represents the number of ERL activations that can be performed in a ca
 
 When ERL is triggered, it will keep activated for the `erl_activation_period_seconds` defined in the bucket configuration.
 
-The amount of minutes per month allowed in ERL mode is defined by: `per_calendar_month * erl_activation_period_seconds / 60`.
-
+The amount of minutes per month allowed in ERL mode is defined by: `quota_per_calendar_month * erl_activation_period_seconds / 60`.
 
 The overrides in ERL work the same way as for the regular bucket. Both size and per_interval are mandatory when specifying an override. 
 
@@ -200,7 +199,6 @@ limitd.takeElevated(type, key, { count, configOverride, elevated_limits }, (err,
 -  `elevated_limits`: (object)
   - `erl_is_active_key`: (string) the identifier of the ERL activation for the bucket.
   - `erl_quota_key`: (string) the identifier of the ERL quota bucket name.
-  - `per_calendar_month`: (number) the amount of tokens that the quota bucket will receive on every calendar month.
 
 `erlQuota.per_calendar_month` is the only refill rate available for ERL quota buckets at the moment. 
 The quota bucket will be used to track the amount of ERL activations that can be done in a calendar month. 

--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ buckets = {
   ip: {
     size: 10,
     per_second: 5,
-    elevated_limits: {
-      size: 100, // new bucket size. already used tokens will be deducted from current bucket content upon ERL activation.
-      per_second: 50, // new bucket refill rate. You can use all the other refill rate configurations defined above, such as per_minute, per_hour, per_interval etc.
-      erl_activation_period_seconds: 300, // for how long the ERL configuration should remain active once activated.
-      quota_per_calendar_month: 100, // the amount of ERL activations that can be done in a calendar month. Each activation will remain active during erl_activation_period_seconds. 
+    elevated_limits: { // Optional. ERL configuration if needed for the bucket. If not defined, the bucket will not use ERL.
+      size: 100, // Optional. New bucket size. already used tokens will be deducted from current bucket content upon ERL activation. Default: same as the original bucket.
+      per_second: 50, // Optional. New bucket refill rate. You can use all the other refill rate configurations defined above, such as per_minute, per_hour, per_interval etc. Default: same as the original bucket.
+      erl_activation_period_seconds: 300, // Mandatory. For how long the ERL configuration should remain active once activated. No default value.
+      quota_per_calendar_month: 100, // Mandatory. The amount of ERL activations that can be done in a calendar month. Each activation will remain active during erl_activation_period_seconds. 
     }
   }
 }
@@ -265,6 +265,24 @@ limitd.take(type, key, { count: 3, configOverride }, (err, result) => {
 ```
 
 Config overrides follow the same rules as Bucket configuration elements with respect to default size when not provided and ttl.
+
+### Overriding Configuration at Runtime with ERL
+We can also override the configuration for ERL buckets at runtime. The shape of this `configOverride` parameter is the same as `Buckets` above.
+
+An example configuration override call for ERL might look like this:
+
+```js
+const configOverride = {
+  size: 45,
+  per_hour: 15,
+  elevated_limits: {
+    size: 100,
+    per_hour: 50,
+    erl_activation_period_seconds: 300,
+    quota_per_calendar_month: 100
+  }
+}
+```
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -217,15 +217,14 @@ The result object has:
 -  `elevated_limits` (object)
   -  `triggered` (boolean): true if ERL was triggered in the current request.
   -  `activated` (boolean): true if ERL is activated. Not necessarily triggered in this call.
-  -  `quota_used` (int): **[Only valid if triggered=true]** If `triggered=true`, this value contains the current quota count for the given `erl_quota_key`. Otherwise, it will return -1, which is not valid to be interpreted as a quota count.
+  -  `quota_remaining` (int): **[Only valid if triggered=true]** If `triggered=true`, this value contains the remaining quota count for the given `erl_quota_key`. Otherwise, it will return -1, which is not valid to be interpreted as a quota count.
   -  `quota_allocated`: (int): amount of quota allocated in the bucket configuration. This value is defined in the bucket configuration and is the same as `quota_per_calendar_month`.
   -  `erl_activation_period_seconds`: (int): the ERL activation period as defined in the bucket configuration used in the current request.
 
 Example of interpretation:
 ``` javascript
-if erl_activated && erl_quota_count >= 0; // quota left in the quotaKey bucket
-if erl_activated && erl_quota_count = -1; // ERL is activated, but it wasn't triggered in this call, so we haven't identified the quota for this call.
-if !erl_activated; // ERL is not activated, hence the quota hasn't been identified for this call. 
+if erl_triggered // quota left in the quotaKey bucket
+if !erl_triggered // ERL wasn't triggered in this call, so we haven't identified the remaining quota.
 ```
 
 ## PUT

--- a/lib/db.js
+++ b/lib/db.js
@@ -304,6 +304,7 @@ class LimitDBRedis extends EventEmitter {
         erl_activation_period_seconds: 900,
         erl_quota_amount: 0,
         erl_quota_interval: 'quota_per_calendar_month',
+        erl_configured_for_bucket: false,
         ...bucketKeyConfig.elevated_limits
       };
 
@@ -319,6 +320,7 @@ class LimitDBRedis extends EventEmitter {
         elevated_limits.erl_activation_period_seconds,
         elevated_limits.erl_quota_amount,
         erl_quota_expiration,
+        elevated_limits.erl_configured_for_bucket ? 1 : 0,
         (err, results) => {
           if (err) {
             return callback(err);
@@ -337,6 +339,7 @@ class LimitDBRedis extends EventEmitter {
             limit: erl_activated ? elevated_limits.size : bucketKeyConfig.size,
             delayed: false,
             elevated_limits : {
+              erl_configured_for_bucket: elevated_limits.erl_configured_for_bucket,
               triggered: erl_triggered,
               activated: erl_activated,
               quota_remaining: erl_quota_count,

--- a/lib/db.js
+++ b/lib/db.js
@@ -5,7 +5,7 @@ const async = require('async');
 const LRU = require('lru-cache');
 const utils = require('./utils');
 const Redis = require('ioredis');
-const { validateParams, validateConfigIsForElevatedBucket, validateERLParams } = require('./validation');
+const { validateParams, validateERLParams } = require('./validation');
 const DBPing = require("./db_ping");
 const { calculateQuotaExpiration } = require('./utils');
 const EventEmitter = require('events').EventEmitter;
@@ -297,21 +297,27 @@ class LimitDBRedis extends EventEmitter {
     const erlParams = utils.getERLParams(params.elevated_limits);
 
     this._doTake(params, callback, (key, bucketKeyConfig, count) => {
-      const valError = validateConfigIsForElevatedBucket(key, bucketKeyConfig)
-      if (valError) {
-        return callback(valError)
-      }
-      const erl_quota_expiration = calculateQuotaExpiration(bucketKeyConfig.elevated_limits);
+      // provide default values for elevated_limits unless the bucketKeyConfig has them
+      const elevated_limits = {
+        ms_per_interval: bucketKeyConfig.ms_per_interval,
+        size: bucketKeyConfig.size,
+        erl_activation_period_seconds: 900,
+        erl_quota_amount: 0,
+        erl_quota_interval: 'quota_per_calendar_month',
+        ...bucketKeyConfig.elevated_limits
+      };
+
+      const erl_quota_expiration = calculateQuotaExpiration(elevated_limits);
       this.redis.takeElevated(key, erlParams.erl_is_active_key, erlParams.erl_quota_key,
         bucketKeyConfig.ms_per_interval || 0,
         bucketKeyConfig.size,
         count,
         Math.ceil(bucketKeyConfig.ttl || this.globalTTL),
         bucketKeyConfig.drip_interval || 0,
-        bucketKeyConfig.elevated_limits.ms_per_interval || 0,
-        bucketKeyConfig.elevated_limits.size,
-        bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
-        bucketKeyConfig.elevated_limits.erl_quota_amount,
+        elevated_limits.ms_per_interval,
+        elevated_limits.size,
+        elevated_limits.erl_activation_period_seconds,
+        elevated_limits.erl_quota_amount,
         erl_quota_expiration,
         (err, results) => {
           if (err) {
@@ -334,8 +340,8 @@ class LimitDBRedis extends EventEmitter {
               triggered: erl_triggered,
               activated: erl_activated,
               quota_remaining: erl_quota_count,
-              quota_allocated: bucketKeyConfig.elevated_limits.erl_quota_amount,
-              erl_activation_period_seconds: bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
+              quota_allocated: elevated_limits.erl_quota_amount,
+              erl_activation_period_seconds: elevated_limits.erl_activation_period_seconds,
             },
           };
           if (bucketKeyConfig.skip_n_calls > 0) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -7,6 +7,7 @@ const utils = require('./utils');
 const Redis = require('ioredis');
 const { validateParams, validateConfigIsForElevatedBucket, validateERLParams } = require('./validation');
 const DBPing = require("./db_ping");
+const { calculateQuotaExpiration } = require('./utils');
 const EventEmitter = require('events').EventEmitter;
 
 const TAKE_LUA = fs.readFileSync(`${__dirname}/take.lua`, "utf8");
@@ -289,24 +290,18 @@ class LimitDBRedis extends EventEmitter {
   }
 
   takeElevated(params, callback) {
-    const valERLParamsError = validateERLParams(params.elevated_limits);
-    if (valERLParamsError) {
-      return callback(valERLParamsError)
+    const valError = validateERLParams(params.elevated_limits);
+    if (valError) {
+      return callback(valError)
     }
-    const erlParams = utils.getERLKeysQuotaAmountAndExpiration(params.elevated_limits);
+    const erlParams = utils.getERLParams(params.elevated_limits);
 
     this._doTake(params, callback, (key, bucketKeyConfig, count) => {
-      const valERLConfigError = validateConfigIsForElevatedBucket(key, bucketKeyConfig)
-      const isERLEnabledForBucket = !valERLConfigError;
-      if (valERLConfigError) {
-      
-        bucketKeyConfig.elevated_limits = {
-          ms_per_interval: bucketKeyConfig.ms_per_interval,
-          size: bucketKeyConfig.size,
-          erl_activation_period_seconds: 0
-        }
+      const valError = validateConfigIsForElevatedBucket(key, bucketKeyConfig)
+      if (valError) {
+        return callback(valError)
       }
-
+      const erl_quota_expiration = calculateQuotaExpiration(bucketKeyConfig.elevated_limits);
       this.redis.takeElevated(key, erlParams.erl_is_active_key, erlParams.erl_quota_key,
         bucketKeyConfig.ms_per_interval || 0,
         bucketKeyConfig.size,
@@ -316,9 +311,8 @@ class LimitDBRedis extends EventEmitter {
         bucketKeyConfig.elevated_limits.ms_per_interval || 0,
         bucketKeyConfig.elevated_limits.size,
         bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
-        erlParams.erl_quota_amount,
-        erlParams.erl_quota_expiration,
-        isERLEnabledForBucket,
+        bucketKeyConfig.elevated_limits.erl_quota_amount,
+        erl_quota_expiration,
         (err, results) => {
           if (err) {
             return callback(err);

--- a/lib/db.js
+++ b/lib/db.js
@@ -333,7 +333,9 @@ class LimitDBRedis extends EventEmitter {
             elevated_limits : {
               triggered: erl_triggered,
               activated: erl_activated,
-              quota_count: erl_quota_count
+              quota_used: erl_quota_count,
+              quota_allocated: bucketKeyConfig.elevated_limits.erl_quota_amount,
+              erl_activation_period_seconds: bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
             },
           };
           if (bucketKeyConfig.skip_n_calls > 0) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -334,7 +334,7 @@ class LimitDBRedis extends EventEmitter {
             conformant,
             remaining,
             reset: Math.ceil(reset / 1000),
-            limit: bucketKeyConfig.size,
+            limit: erl_activated ? elevated_limits.size : bucketKeyConfig.size,
             delayed: false,
             elevated_limits : {
               triggered: erl_triggered,

--- a/lib/db.js
+++ b/lib/db.js
@@ -330,18 +330,20 @@ class LimitDBRedis extends EventEmitter {
           const currentMS = parseInt(results[2], 10);
           const reset = parseInt(results[3], 10);
           const erl_triggered = parseInt(results[4], 10) ? true : false;
-          const erl_activated = parseInt(results[5], 10) ? true : false;
+          let erl_activate_for_bucket = parseInt(results[5], 10) ? true : false;
+          // if the bucket is not configured for elevated limits, then it shouldn't be activated
+          erl_activate_for_bucket = erl_activate_for_bucket && elevated_limits.erl_configured_for_bucket;
           const erl_quota_count = parseInt(results[6], 10);
           const res = {
             conformant,
             remaining,
             reset: Math.ceil(reset / 1000),
-            limit: erl_activated ? elevated_limits.size : bucketKeyConfig.size,
+            limit: erl_activate_for_bucket ? elevated_limits.size : bucketKeyConfig.size,
             delayed: false,
             elevated_limits : {
               erl_configured_for_bucket: elevated_limits.erl_configured_for_bucket,
               triggered: erl_triggered,
-              activated: erl_activated,
+              activated: erl_activate_for_bucket,
               quota_remaining: erl_quota_count,
               quota_allocated: elevated_limits.erl_quota_amount,
               erl_activation_period_seconds: elevated_limits.erl_activation_period_seconds,

--- a/lib/db.js
+++ b/lib/db.js
@@ -333,7 +333,7 @@ class LimitDBRedis extends EventEmitter {
             elevated_limits : {
               triggered: erl_triggered,
               activated: erl_activated,
-              quota_used: erl_quota_count,
+              quota_remaining: erl_quota_count,
               quota_allocated: bucketKeyConfig.elevated_limits.erl_quota_amount,
               erl_activation_period_seconds: bucketKeyConfig.elevated_limits.erl_activation_period_seconds,
             },

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -47,17 +47,28 @@ local function calculateNewBucketContent(current, tokens_per_ms, bucket_size, cu
 end
 
 local function takeERLQuota(erl_quota_key, erl_quota_amount, erl_quota_expiration_epoch)
-    local erl_quota = 0
-    local get_quota_result = redis.call('GET', erl_quota_key)
-    if type(get_quota_result) == 'string' then
-        erl_quota = tonumber(get_quota_result)
+    if erl_quota_amount <= 0 then
+        -- no quota available to take
+        return 0
     end
 
-    if erl_quota < erl_quota_amount then
-        erl_quota = erl_quota + 1
-        redis.call('SET', erl_quota_key, erl_quota, 'PXAT', string.format('%.0f', erl_quota_expiration_epoch))
+    local get_quota_result = redis.call('GET', erl_quota_key)
+    if type(get_quota_result) ~= 'string' then
+        -- first activation. Set quota to 1 and return.
+        redis.call('SET', erl_quota_key, 1, 'PXAT', string.format('%.0f', erl_quota_expiration_epoch))
+        return 1
     end
-    return erl_quota
+
+    local erl_quota_used = tonumber(get_quota_result)
+    if erl_quota_used >= erl_quota_amount then
+        -- quota is exceeded. Return the current quota.
+        return erl_quota_used
+    end
+
+    -- quota is not exceeded. Increment and return.
+    local new_quota = erl_quota_used + 1
+    redis.call('SET', erl_quota_key, new_quota, 'PXAT', string.format('%.0f', erl_quota_expiration_epoch))
+    return new_quota
 end
 
 -- Enable verbatim replication to ensure redis sends script's source code to all masters
@@ -91,8 +102,8 @@ else
         local bucket_content_after_erl_activation = erl_bucket_size - used_tokens
         local enough_tokens_after_erl_activation = bucket_content_after_erl_activation >= tokens_to_take
         if enough_tokens_after_erl_activation then
-            local erl_quota = takeERLQuota(erl_quota_key, erl_quota_amount, erl_quota_expiration_epoch)
-            if erl_quota < erl_quota_amount then
+            local erl_quota_used = takeERLQuota(erl_quota_key, erl_quota_amount, erl_quota_expiration_epoch)
+            if erl_quota_used < erl_quota_amount then
                 enough_tokens = enough_tokens_after_erl_activation -- we are returning this value, thus setting it
                 bucket_content_after_take = math.min(bucket_content_after_erl_activation - tokens_to_take, erl_bucket_size)
                 -- save erl state
@@ -100,7 +111,7 @@ else
                 redis.call('EXPIRE', erlKey, erl_activation_period_seconds)
                 is_erl_activated = 1
                 erl_triggered = true
-                erl_quota_left = erl_quota_amount - erl_quota
+                erl_quota_left = erl_quota_amount - erl_quota_used
             end
         end
     end

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,6 +72,8 @@ function normalizeElevatedTemporals(params) {
     throw new LimitdRedisConfigurationError('a valid quota amount per interval is required for elevated limits', {code: 202});
   }
 
+  type.erl_configured_for_bucket = true;
+
   return type;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,16 +12,10 @@ const INTERVAL_TO_MS = {
 const INTERVAL_SHORTCUTS = Object.keys(INTERVAL_TO_MS);
 
 const ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH = 'quota_per_calendar_month';
-const ERL_QUOTA_INTERVALS = {};
-ERL_QUOTA_INTERVALS[ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH] = () => endOfMonthTimestamp();
-const ERL_QUOTA_INTERVALS_SHORTCUTS = Object.keys(ERL_QUOTA_INTERVALS);
-
-const ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS = 15 * 60;
-const ERL_DEFAULT_QUOTA_AMOUNT = 0;
-const ERL_DEFAULT_VALUES = {
-  erl_activation_period_seconds: ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS,
-  quota_per_calendar_month: ERL_DEFAULT_QUOTA_AMOUNT,
+const ERL_QUOTA_INTERVALS = {
+  [ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH]: () => endOfMonthTimestamp()
 };
+const ERL_QUOTA_INTERVALS_SHORTCUTS = Object.keys(ERL_QUOTA_INTERVALS);
 
 function normalizeTemporals(params) {
   const type = _.pick(params, [
@@ -58,15 +52,12 @@ function normalizeTemporals(params) {
 }
 
 function normalizeElevatedTemporals(params) {
-  if (!params) {
-    return;
+  if (!params.erl_activation_period_seconds) {
+    throw new LimitdRedisConfigurationError('erl_activation_period_seconds is required for elevated limits', {code: 201});
   }
 
   let type = normalizeTemporals(params);
-
-  if (params.erl_activation_period_seconds) {
-    type.erl_activation_period_seconds = params.erl_activation_period_seconds;
-  }
+  type.erl_activation_period_seconds = params.erl_activation_period_seconds;
 
   // extract erl quota information
   ERL_QUOTA_INTERVALS_SHORTCUTS.forEach(intervalShortcut => {
@@ -77,23 +68,14 @@ function normalizeElevatedTemporals(params) {
     type.erl_quota_interval = intervalShortcut;
   });
 
+  if (!type.erl_quota_interval || type.erl_quota_amount === undefined) {
+    throw new LimitdRedisConfigurationError('a valid quota amount per interval is required for elevated limits', {code: 202});
+  }
+
   return type;
 }
 
-function getElevatedParamsOrDefault(params) {
-  if (params.elevated_limits) {
-    return params.elevated_limits;
-  }
-
-  // as a default for elevated limits we'll use the same size and interval as the bucket
-  // only extract size and interval from params
-  let { overrides, ...sizeAndInterval } = params;
-  return { ...sizeAndInterval, ...ERL_DEFAULT_VALUES };
-}
-
 function normalizeType(params) {
-  params.elevated_limits = getElevatedParamsOrDefault(params);
-
   const type = normalizeTemporals(params);
 
   type.overridesMatch = {};
@@ -180,6 +162,18 @@ function endOfMonthTimestamp() {
   return Date.UTC(curDate.getUTCFullYear(), curDate.getUTCMonth() + 1, 1, 0, 0, 0, 0);
 }
 
+class LimitdRedisConfigurationError extends Error {
+  constructor(msg, extra) {
+    super();
+    this.name = this.constructor.name;
+    this.message = msg;
+    Error.captureStackTrace(this, this.constructor);
+    if (extra) {
+      this.extra = extra;
+    }
+  }
+}
+
 module.exports = {
   buildBuckets,
   buildBucket,
@@ -189,7 +183,6 @@ module.exports = {
   normalizeType,
   functionOrFalse,
   randomBetween,
-  ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS,
   getERLParams,
   endOfMonthTimestamp,
   calculateQuotaExpiration

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,12 +11,17 @@ const INTERVAL_TO_MS = {
 
 const INTERVAL_SHORTCUTS = Object.keys(INTERVAL_TO_MS);
 
-const ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH = 'per_calendar_month';
+const ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH = 'quota_per_calendar_month';
 const ERL_QUOTA_INTERVALS = {};
 ERL_QUOTA_INTERVALS[ERL_QUOTA_INTERVAL_PER_CALENDAR_MONTH] = () => endOfMonthTimestamp();
+const ERL_QUOTA_INTERVALS_SHORTCUTS = Object.keys(ERL_QUOTA_INTERVALS);
 
 const ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS = 15 * 60;
-const ERL_QUOTA_INTERVALS_SHORTCUTS = Object.keys(ERL_QUOTA_INTERVALS);
+const ERL_DEFAULT_QUOTA_AMOUNT = 0;
+const ERL_DEFAULT_VALUES = {
+  erl_activation_period_seconds: ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS,
+  quota_per_calendar_month: ERL_DEFAULT_QUOTA_AMOUNT,
+};
 
 function normalizeTemporals(params) {
   const type = _.pick(params, [
@@ -59,16 +64,36 @@ function normalizeElevatedTemporals(params) {
 
   let type = normalizeTemporals(params);
 
-  if (!params.erl_activation_period_seconds) {
-    type.erl_activation_period_seconds = ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS;
-  } else {
+  if (params.erl_activation_period_seconds) {
     type.erl_activation_period_seconds = params.erl_activation_period_seconds;
   }
+
+  // extract erl quota information
+  ERL_QUOTA_INTERVALS_SHORTCUTS.forEach(intervalShortcut => {
+    if (!(intervalShortcut in params)) {
+      return;
+    }
+    type.erl_quota_amount = params[intervalShortcut];
+    type.erl_quota_interval = intervalShortcut;
+  });
 
   return type;
 }
 
+function getElevatedParamsOrDefault(params) {
+  if (params.elevated_limits) {
+    return params.elevated_limits;
+  }
+
+  // as a default for elevated limits we'll use the same size and interval as the bucket
+  // only extract size and interval from params
+  let { overrides, ...sizeAndInterval } = params;
+  return { ...sizeAndInterval, ...ERL_DEFAULT_VALUES };
+}
+
 function normalizeType(params) {
+  params.elevated_limits = getElevatedParamsOrDefault(params);
+
   const type = normalizeTemporals(params);
 
   type.overridesMatch = {};
@@ -139,23 +164,15 @@ function randomBetween(min, max) {
   return Math.random() * (max - min) + min;
 }
 
-function getERLKeysQuotaAmountAndExpiration(params) {
-  const type = _.pick(params, [
+function getERLParams(params) {
+  return _.pick(params, [
     'erl_is_active_key',
-    'erl_quota_key',
-    'erl_quota_amount',
-    'erl_quota_expiration'
+    'erl_quota_key'
   ]);
+}
 
-  ERL_QUOTA_INTERVALS_SHORTCUTS.forEach(intervalShortcut => {
-    if (!(intervalShortcut in params)) {
-      return;
-    }
-    type.erl_quota_amount = params[intervalShortcut];
-    type.erl_quota_expiration = ERL_QUOTA_INTERVALS[intervalShortcut]();
-  });
-
-  return type;
+function calculateQuotaExpiration(params) {
+  return ERL_QUOTA_INTERVALS[params.erl_quota_interval]();
 }
 
 function endOfMonthTimestamp() {
@@ -173,6 +190,7 @@ module.exports = {
   functionOrFalse,
   randomBetween,
   ERL_DEFAULT_ACTIVATION_PERIOD_SECONDS,
-  getERLKeysQuotaAmountAndExpiration,
-  endOfMonthTimestamp
+  getERLParams,
+  endOfMonthTimestamp,
+  calculateQuotaExpiration
 };

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,12 +1,4 @@
-const { INTERVAL_SHORTCUTS, ERL_QUOTA_INTERVALS_SHORTCUTS } = require('./utils');
-
-const ERL_BUCKET_KEYS = [
-  'size', 'per_interval', 'erl_activation_period_seconds', 'erl_quota_amount', 'erl_quota_interval'
-];
-
-const ERL_MANDATORY_KEYS = [
-  'size', 'per_interval', 'erl_activation_period_seconds', 'quota_per_calendar_month'
-];
+const { INTERVAL_SHORTCUTS } = require('./utils');
 
 class LimitdRedisValidationError extends Error {
   constructor(msg, extra) {
@@ -81,24 +73,8 @@ function validateERLParams(params) {
   }
 }
 
-function validateConfigIsForElevatedBucket(key, bucketKeyConfig) {
-  if (!isConfigForElevatedBucket(bucketKeyConfig)) {
-    return new LimitdRedisValidationError('Attempted to takeElevated() for a bucket with no elevated config.' +
-      `bucket:${key}, bucketKeyConfig:${JSON.stringify(bucketKeyConfig)}.` +
-      `Please check the bucket configuration contains all the required keys for elevated limits: ${ERL_MANDATORY_KEYS}.`,
-      { code: 109 });
-  }
-}
-
-function isConfigForElevatedBucket(bucketKeyConfig) {
-  // validate if all keys in ERL_BUCKET_KEYS are present in bucketKeyConfig.elevated_limits
-  return bucketKeyConfig.elevated_limits
-    && ERL_BUCKET_KEYS.every(key => bucketKeyConfig.elevated_limits.hasOwnProperty(key));
-}
-
 module.exports = {
   validateParams,
   validateERLParams,
-  validateConfigIsForElevatedBucket,
   LimitdRedisValidationError,
 };

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -1,5 +1,13 @@
 const { INTERVAL_SHORTCUTS, ERL_QUOTA_INTERVALS_SHORTCUTS } = require('./utils');
 
+const ERL_BUCKET_KEYS = [
+  'size', 'per_interval', 'erl_activation_period_seconds', 'erl_quota_amount', 'erl_quota_interval'
+];
+
+const ERL_MANDATORY_KEYS = [
+  'size', 'per_interval', 'erl_activation_period_seconds', 'quota_per_calendar_month'
+];
+
 class LimitdRedisValidationError extends Error {
   constructor(msg, extra) {
     super();
@@ -68,39 +76,24 @@ function validateERLParams(params) {
     return new LimitdRedisValidationError('erl_is_active_key is required for elevated limits', { code: 108 });
   }
 
-  return validateERLQuota(params);
-}
-
-function validateERLQuota(params) {
   if (typeof params.erl_quota_key !== 'string') {
     return new LimitdRedisValidationError('erl_quota_key is required for elevated limits', { code: 110 });
   }
-
-  if (!containsERLQuotaInterval(params)) {
-    return new LimitdRedisValidationError('corresponding per_interval is required for elevated limits', { code: 111 });
-  }
-}
-
-function containsERLQuotaInterval(params) {
-  const interval = Object.keys(params)
-    .find(key => ERL_QUOTA_INTERVALS_SHORTCUTS.indexOf(key) > -1);
-
-  return interval !== undefined;
 }
 
 function validateConfigIsForElevatedBucket(key, bucketKeyConfig) {
   if (!isConfigForElevatedBucket(bucketKeyConfig)) {
-    return new LimitdRedisValidationError(`Attempted to takeElevated() for a bucket with no elevated config. bucket:${key}, bucketKeyConfig:${JSON.stringify(bucketKeyConfig)}`,
+    return new LimitdRedisValidationError('Attempted to takeElevated() for a bucket with no elevated config.' +
+      `bucket:${key}, bucketKeyConfig:${JSON.stringify(bucketKeyConfig)}.` +
+      `Please check the bucket configuration contains all the required keys for elevated limits: ${ERL_MANDATORY_KEYS}.`,
       { code: 109 });
   }
 }
 
 function isConfigForElevatedBucket(bucketKeyConfig) {
+  // validate if all keys in ERL_BUCKET_KEYS are present in bucketKeyConfig.elevated_limits
   return bucketKeyConfig.elevated_limits
-    && bucketKeyConfig.elevated_limits.size
-    && bucketKeyConfig.elevated_limits.per_interval
-    && bucketKeyConfig.elevated_limits.erl_activation_period_seconds;
-
+    && ERL_BUCKET_KEYS.every(key => bucketKeyConfig.elevated_limits.hasOwnProperty(key));
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
+    "chai-exclude": "^2.1.0",
     "eslint": "^6.1.0",
     "mocha": "^5.2.0",
+    "mockdate": "^3.0.5",
     "nyc": "^14.1.1",
-    "toxiproxy-node-client": "^2.0.6",
-    "mockdate": "^3.0.5"
+    "toxiproxy-node-client": "^2.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd-redis",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "description": "A database client for limits on top of redis",
   "main": "index.js",
   "repository": {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -137,13 +137,12 @@ describe('LimitdRedis', () => {
 
   describe('#takeElevated', () => {
     it('should call #handle with takeElevated as the method', (done) => {
-      const elevated_limits = { erl_is_active_key: 'erlKEY', erl_quota_key: 'quotaKEY', per_calendar_month: 100 };
+      const elevated_limits = { erl_is_active_key: 'erlKEY', erl_quota_key: 'quotaKEY' };
       client.handler = (method, type, key, opts, cb) => {
         assert.equal(method, 'takeElevated');
         assert.isNotNull(opts.elevated_limits);
         assert.equal(opts.elevated_limits.erl_is_active_key, elevated_limits.erl_is_active_key);
         assert.equal(opts.elevated_limits.erl_quota_key, elevated_limits.erl_quota_key);
-        assert.equal(opts.elevated_limits.per_calendar_month, elevated_limits.per_calendar_month);
         cb();
       };
       client.takeElevated('test', 'test', { elevated_limits: elevated_limits }, done);

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -177,14 +177,13 @@ describe('LimitDBRedis', () => {
     const testsParams = [
       {
         name: 'regular take',
-        init: () => {
-        },
+        init: () => db.configurateBuckets(buckets),
         take: (params, callback) => db.take(params, callback),
         params: {}
       },
       {
         name: 'elevated take with no elevated configuration',
-        init: () => {},
+        init: () => db.configurateBuckets(buckets),
         take: (params, callback) => db.takeElevated(params, callback),
         params: {
           elevated_limits: {
@@ -228,6 +227,7 @@ describe('LimitDBRedis', () => {
                 return done(err);
               }
               assert.equal(result.conformant, true);
+              assert.equal(result.limit, 10);
               assert.equal(result.remaining, 8);
               done();
             });
@@ -339,6 +339,7 @@ describe('LimitDBRedis', () => {
             }));
             testParams.take(takeParams, (err, response) => {
               assert.notOk(response.conformant);
+              assert.equal(response.limit, 10);
               assert.equal(response.remaining, 0);
               done();
             });
@@ -360,6 +361,7 @@ describe('LimitDBRedis', () => {
               if (err) return done(err);
               assert.ok(result.conformant);
               assert.ok(result.remaining, 89);
+              assert.equal(result.limit, 100);
               done();
             });
           });
@@ -379,6 +381,7 @@ describe('LimitDBRedis', () => {
             testParams.take(takeParams, (err, result) => {
               assert.ok(result.conformant);
               assert.ok(result.remaining, 39);
+              assert.equal(result.limit, 50);
               done();
             });
           });
@@ -457,15 +460,15 @@ describe('LimitDBRedis', () => {
           });
         });
 
-        it(`should work for unlimited`, (done) => {
+        it(`should not reduce tokens for unlimited`, (done) => {
           testParams.init();
           const now = Date.now();
           testParams.take({ ...testParams.params, type: 'ip', key: '0.0.0.0' }, (err, response) => {
             if (err) return done(err);
             assert.ok(response.conformant);
+            assert.equal(response.limit, 100);
             assert.equal(response.remaining, 100);
             assert.closeTo(response.reset, now / 1000, 1);
-            assert.equal(response.limit, 100);
             done();
           });
         });
@@ -763,6 +766,7 @@ describe('LimitDBRedis', () => {
       const takeParams = { type: 'tenant', key: 'foo' };
       db.take(takeParams, (err, response) => {
         assert.ok(response.conformant);
+        assert.equal(response.limit, 1);
         assert.equal(response.remaining, 0);
         done();
       });
@@ -788,6 +792,7 @@ describe('LimitDBRedis', () => {
         }));
         db.take(takeParams, (err, response) => {
           assert.notOk(response.conformant);
+          assert.equal(response.limit, 10);
           assert.equal(response.remaining, 0);
           done();
         });
@@ -974,11 +979,13 @@ describe('LimitDBRedis', () => {
         // first call, still within normal rate limits
         await takeElevatedPromise(params).then((result) => {
           assert.isFalse(result.elevated_limits.activated);
+          assert.equal(result.limit, 1);
         });
         // second call, normal rate limits exceeded and erl is activated
         await takeElevatedPromise(params).then((result) => {
           assert.isTrue(result.elevated_limits.activated);
           assert.isTrue(result.conformant);
+          assert.equal(result.limit, 10);
           assert.equal(result.remaining, 8);
         });
 
@@ -1006,6 +1013,7 @@ describe('LimitDBRedis', () => {
           assert.isTrue(result.conformant);
           assert.isFalse(result.elevated_limits.activated);
           assert.equal(result.remaining, 0);
+          assert.equal(result.limit, 1);
         });
         // second call, normal rate limits exceeded and erl is activated.
         // tokens in bucket is going to be 0 after this call (size 2 - 2 calls)
@@ -1013,12 +1021,14 @@ describe('LimitDBRedis', () => {
           assert.isTrue(result.conformant);
           assert.isTrue(result.elevated_limits.activated);
           assert.equal(result.remaining, 0);
+          assert.equal(result.limit, 2);
         });
         // third call, erl rate limit exceeded
         await takeElevatedPromise(params).then((result) => {
           assert.isFalse(result.conformant); // being rate limited
           assert.isTrue(result.elevated_limits.activated);
           assert.equal(result.remaining, 0);
+          assert.equal(result.limit, 2);
         });
       });
       it('should deduct already used tokens from new bucket when erl is activated', async () => {
@@ -1044,6 +1054,7 @@ describe('LimitDBRedis', () => {
         await takeElevatedPromise(params).then((result) => {
           assert.isTrue(result.conformant);
           assert.isTrue(result.elevated_limits.activated);
+          assert.equal(result.limit, 10);
           assert.equal(result.remaining, 7); // Total used tokens so far: 3
         });
       });
@@ -1129,6 +1140,7 @@ describe('LimitDBRedis', () => {
           .then((result) => {
             assert.isTrue(result.conformant);
             assert.isTrue(result.elevated_limits.activated);
+            assert.equal(result.limit, 5);
             assert.equal(result.remaining, 3);
             done();
           });
@@ -1155,9 +1167,16 @@ describe('LimitDBRedis', () => {
 
         // first call to take a token
         takeElevatedPromise(params)
+          .then((result) => {
+            assert.equal(result.limit, 1);
+            assert.equal(result.remaining, 0);
+          })
           // second call. erl activated and token taken. tokens in bucket: 3
           .then(() => takeElevatedPromise(params))
-          .then((result) => assert.equal(result.remaining, 3))
+          .then((result) => {
+            assert.equal(result.limit, 5);
+            assert.equal(result.remaining, 3);
+          })
           // wait for 10ms, refill 1 token while erl active. tokens in bucket: 4
           .then(() => new Promise((resolve) => setTimeout(resolve, 10)))
           // take 1 token. tokens in bucket: 3
@@ -1166,6 +1185,7 @@ describe('LimitDBRedis', () => {
             assert.isTrue(result.conformant);
             assert.isTrue(result.elevated_limits.activated);
             assert.equal(result.remaining, 3);
+            assert.equal(result.limit, 5);
           })
           // disable ERL, go back to standard bucket size and refill rate
           // tokens in bucket: 1 (= bucket size)
@@ -1175,6 +1195,7 @@ describe('LimitDBRedis', () => {
             assert.isTrue(result.conformant);
             assert.notExists(result.elevated_limits);
             assert.equal(result.remaining, 0);
+            assert.equal(result.limit, 1);
           })
           // wait for 2ms, refill 1 token while erl inactive. tokens in bucket: 1
           .then(() => new Promise((resolve) => setTimeout(resolve, 20)))
@@ -1184,6 +1205,7 @@ describe('LimitDBRedis', () => {
             assert.isTrue(result.conformant);
             assert.notExists(result.elevated_limits);
             assert.equal(result.remaining, 0);
+            assert.equal(result.limit, 1);
             done();
           });
       });
@@ -1233,7 +1255,8 @@ describe('LimitDBRedis', () => {
           it('should take from the erl bucket', async () => {
             await takeElevatedPromise(erlParams)
             const result = await takeElevatedPromise(erlParams);
-            assert.isTrue(result.conformant)
+            assert.isTrue(result.conformant);
+            assert.equal(result.limit, 5);
           })
         })
       })
@@ -1264,12 +1287,15 @@ describe('LimitDBRedis', () => {
             .then((result) => {
               assert.isTrue(result.conformant);
               assert.isFalse(result.elevated_limits.activated);
+              assert.equal(result.limit, 1);
+              assert.equal(result.remaining, 0);
             })
             .then(() => takeElevatedPromise(params))
             .then(() => takeElevatedPromise(params))
             .then((result) => {
               assert.isTrue(result.conformant);
               assert.isTrue(result.elevated_limits.activated);
+              assert.equal(result.limit, 3);
               assert.equal(result.remaining, 0);
             })
             .then(() => takeElevatedPromise(params))
@@ -1364,6 +1390,7 @@ describe('LimitDBRedis', () => {
               assert.equal(response.elevated_limits.quota_remaining, quota_per_calendar_month-1);
               assert.isAtLeast(response.elevated_limits.erl_activation_period_seconds, 900);
               assert.isAtLeast(response.elevated_limits.quota_allocated, quota_per_calendar_month);
+              assert.equal(response.limit, 2);
             })
             .then(() => done());
         });
@@ -1380,6 +1407,7 @@ describe('LimitDBRedis', () => {
               assert.isFalse(response.elevated_limits.triggered);
               assert.isTrue(response.elevated_limits.activated);
               assert.equal(response.elevated_limits.quota_remaining, -1);
+              assert.equal(response.limit, 2);
             })
             .then(() => done());
         });
@@ -1518,6 +1546,7 @@ describe('LimitDBRedis', () => {
             .then((result) => {
               assert.isTrue(result.conformant);
               assert.isFalse(result.elevated_limits.activated);
+              assert.equal(result.limit, 1);
             })
             .then(() => redisExistsPromise(erl_is_active_key))
             .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
@@ -1526,6 +1555,7 @@ describe('LimitDBRedis', () => {
             .then((result) => {
               assert.isFalse(result.conformant);
               assert.isFalse(result.elevated_limits.activated);
+              assert.equal(result.limit, 1);
             })
             .then(() => redisExistsPromise(erl_is_active_key))
             .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
@@ -1550,6 +1580,7 @@ describe('LimitDBRedis', () => {
             .then((result) => {
               assert.isTrue(result.conformant);
               assert.isFalse(result.elevated_limits.activated);
+              assert.equal(result.limit, 1);
             })
             .then(() => redisExistsPromise(erl_is_active_key))
             .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
@@ -1558,6 +1589,7 @@ describe('LimitDBRedis', () => {
             .then((result) => {
               assert.isFalse(result.conformant);
               assert.isFalse(result.elevated_limits.activated);
+              assert.equal(result.limit, 1);
             })
             .then(() => redisExistsPromise(erl_is_active_key))
             .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
@@ -1584,6 +1616,7 @@ describe('LimitDBRedis', () => {
             .then((result) => {
               assert.isTrue(result.conformant);
               assert.isFalse(result.elevated_limits.activated);
+              assert.equal(result.limit, 1);
             })
             .then(() => redisExistsPromise(erl_is_active_key))
             .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
@@ -1592,6 +1625,7 @@ describe('LimitDBRedis', () => {
             .then((result) => {
               assert.isFalse(result.conformant);
               assert.isFalse(result.elevated_limits.activated);
+              assert.equal(result.limit, 1);
             })
             .then(() => redisExistsPromise(erl_is_active_key))
             .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 0))
@@ -1609,6 +1643,7 @@ describe('LimitDBRedis', () => {
             .then((result) => {
               assert.isTrue(result.conformant);
               assert.isTrue(result.elevated_limits.activated);
+              assert.equal(result.limit, 2);
             })
             .then(() => redisExistsPromise(erl_is_active_key))
             .then((erl_is_active_keyExists) => assert.equal(erl_is_active_keyExists, 1))

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -40,8 +40,27 @@ describe('utils', () => {
         per_interval: 300,
         ttl: 1,
         ms_per_interval: 0.3,
-        erl_activation_period_seconds: 300
+        erl_activation_period_seconds: 300,
+        erl_configured_for_bucket: true,
       });
+    });
+
+    it('should return normalized bucket without ERL', () => {
+      const bucket = {
+        size: 100,
+        per_second: 100,
+      };
+      const response = normalizeType(bucket);
+      const { elevated_limits, overrides, overridesMatch, overridesCache, ...rest } = response;
+      expect(rest).excluding('drip_interval').to.deep.equal({
+        size: 100,
+        interval: 1000,
+        per_interval: 100,
+        ttl: 1,
+        ms_per_interval: 0.1,
+      });
+
+      expect(elevated_limits).to.be.undefined;
     });
 
 
@@ -89,6 +108,7 @@ describe('utils', () => {
         per_interval: 400,
         ttl: 1,
         ms_per_interval: 0.4,
+        erl_configured_for_bucket: true,
       });
     });
   });

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -43,41 +43,28 @@ describe('utils', () => {
         erl_activation_period_seconds: 300
       });
     });
-    it('should add default ERL configuration', () => {
-      const bucket = {
-        size: 100,
-        per_second: 100,
-      };
-      const response = normalizeType(bucket);
-      const { elevated_limits, overrides, overridesMatch, overridesCache, ...rest } = response;
-      expect(rest).excluding('drip_interval').to.deep.equal({
-        size: 100,
-        interval: 1000,
-        per_interval: 100,
-        ttl: 1,
-        ms_per_interval: 0.1,
-      });
 
-      expect(elevated_limits).excluding('drip_interval').to.deep.equal({
-        size: 100,
-        interval: 1000,
-        per_interval: 100,
-        ttl: 1,
-        ms_per_interval: 0.1,
-        erl_activation_period_seconds: 900,
-        erl_quota_amount: 0,
-        erl_quota_interval: 'quota_per_calendar_month',
-      });
-    });
 
     it('should add overrides', () => {
       const bucket = {
         size: 100,
         per_second: 100,
+        elevated_limits: {
+          size: 200,
+          per_second: 200,
+          erl_activation_period_seconds: 300,
+          quota_per_calendar_month: 5
+        },
         overrides: {
           '127.0.0.1': {
             size: 200,
-            per_second: 200
+            per_second: 200,
+            elevated_limits: {
+              size: 400,
+              per_second: 400,
+              erl_activation_period_seconds: 900,
+              quota_per_calendar_month: 10,
+            },
           }
         }
       };
@@ -95,13 +82,13 @@ describe('utils', () => {
       });
       expect(overrides['127.0.0.1'].elevated_limits).excluding('drip_interval').to.deep.equal({
         erl_activation_period_seconds: 900,
-        erl_quota_amount: 0,
+        erl_quota_amount: 10,
         erl_quota_interval: "quota_per_calendar_month",
-        size: 100,
+        size: 400,
         interval: 1000,
-        per_interval: 100,
+        per_interval: 400,
         ttl: 1,
-        ms_per_interval: 0.1,
+        ms_per_interval: 0.4,
       });
     });
   });

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -1,42 +1,152 @@
 /* eslint-env node, mocha */
-const assert = require('chai').assert;
+//const assert = require('chai').assert;
+const chai = require('chai');
+const chaiExclude = require('chai-exclude');
+chai.use(chaiExclude);
+const assert = chai.assert;
 
-const { getERLKeysQuotaAmountAndExpiration } = require('../lib/utils');
+const { getERLParams, calculateQuotaExpiration, normalizeType } = require('../lib/utils');
 const { set, reset } = require('mockdate');
+const { expect } = require('chai');
 
 describe('utils', () => {
-  describe('extractERLQuota', () => {
-    const dateTests = [{
+  describe('bucketNormalization', () => {
+    it('should return normalized bucket', () => {
+      const bucket = {
+        size: 100,
+        per_second: 100,
+        elevated_limits: {
+          size: 300,
+          per_second: 300,
+          erl_activation_period_seconds: 300,
+          quota_per_calendar_month: 192
+        }
+      };
+      const response = normalizeType(bucket);
+      const { elevated_limits, overrides, overridesMatch, overridesCache, ...rest } = response;
+      expect(rest).excluding('drip_interval').to.deep.equal({
+        size: 100,
+        interval: 1000,
+        per_interval: 100,
+        ttl: 1,
+        ms_per_interval: 0.1,
+      });
+
+      expect(elevated_limits).excluding('drip_interval').to.deep.equal({
+        size: 300,
+        erl_quota_amount: 192,
+        erl_quota_interval: 'quota_per_calendar_month',
+        interval: 1000,
+        per_interval: 300,
+        ttl: 1,
+        ms_per_interval: 0.3,
+        erl_activation_period_seconds: 300
+      });
+    });
+    it('should add default ERL configuration', () => {
+      const bucket = {
+        size: 100,
+        per_second: 100,
+      };
+      const response = normalizeType(bucket);
+      const { elevated_limits, overrides, overridesMatch, overridesCache, ...rest } = response;
+      expect(rest).excluding('drip_interval').to.deep.equal({
+        size: 100,
+        interval: 1000,
+        per_interval: 100,
+        ttl: 1,
+        ms_per_interval: 0.1,
+      });
+
+      expect(elevated_limits).excluding('drip_interval').to.deep.equal({
+        size: 100,
+        interval: 1000,
+        per_interval: 100,
+        ttl: 1,
+        ms_per_interval: 0.1,
+        erl_activation_period_seconds: 900,
+        erl_quota_amount: 0,
+        erl_quota_interval: 'quota_per_calendar_month',
+      });
+    });
+
+    it('should add overrides', () => {
+      const bucket = {
+        size: 100,
+        per_second: 100,
+        overrides: {
+          '127.0.0.1': {
+            size: 200,
+            per_second: 200
+          }
+        }
+      };
+      const response = normalizeType(bucket);
+      const { elevated_limits, overrides, overridesMatch, overridesCache, ...rest } = response;
+      expect(overrides['127.0.0.1']).to.not.be.null;
+      expect(overrides['127.0.0.1']).excluding('drip_interval').excluding('elevated_limits').to.deep.equal({
+        size: 200,
+        interval: 1000,
+        per_interval: 200,
+        ttl: 1,
+        ms_per_interval: 0.2,
+        name: "127.0.0.1",
+        until: undefined
+      });
+      expect(overrides['127.0.0.1'].elevated_limits).excluding('drip_interval').to.deep.equal({
+        erl_activation_period_seconds: 900,
+        erl_quota_amount: 0,
+        erl_quota_interval: "quota_per_calendar_month",
+        size: 100,
+        interval: 1000,
+        per_interval: 100,
+        ttl: 1,
+        ms_per_interval: 0.1,
+      });
+    });
+  });
+
+  describe('quotaExpiration', () => {
+    const tests = [{
       date: '2024-03-15T12:00:00.000Z', expiration: 1711929600000, name: '16 days, 12 hs left to end of month'
     }, {
       date: '2024-03-31T23:00:00.000Z', expiration: 1711929600000, name: '1 hour left to end of month'
     }, {
       date: '2024-03-31T23:59:59.000Z', expiration: 1711929600000, name: '1 second left to end of month'
+    }, {
+      date: '2024-04-01T00:00:00.000Z', expiration: 1714521600000, name: 'the whole next month'
     }];
 
-    dateTests.forEach(test => {
-      it(`should return appropriate key, amount, and expiration when there's ${test.name}`, () => {
+    tests.forEach(test => {
+      it(`should return appropriate expiration when there's ${test.name}`, () => {
         set(test.date);
 
-        const params = {
-          elevated_limits: {
-            erl_is_active_key: 'erl_is_active_key',
-            erl_quota_key: 'erl_quota_key',
-            per_calendar_month: 192
-          }
-        };
+        const result = calculateQuotaExpiration({ erl_quota_interval: 'quota_per_calendar_month' });
 
-        const result = getERLKeysQuotaAmountAndExpiration(params.elevated_limits);
-
-        assert.equal(result.erl_is_active_key, params.elevated_limits.erl_is_active_key);
-        assert.equal(result.erl_quota_key, params.elevated_limits.erl_quota_key);
-        assert.equal(result.erl_quota_amount, params.elevated_limits.per_calendar_month);
-        assert.equal(result.erl_quota_expiration, test.expiration);
+        assert.equal(result, test.expiration);
       });
+
     });
 
     afterEach(() => {
       reset();
+    });
+
+  });
+
+  describe('extractERLKeys', () => {
+    it('should return appropriate keys', () => {
+      const params = {
+        elevated_limits: {
+          erl_is_active_key: 'erl_is_active_key',
+          erl_quota_key: 'erl_quota_key',
+        }
+      };
+
+      const result = getERLParams(params.elevated_limits);
+
+      assert.equal(result.erl_is_active_key, params.elevated_limits.erl_is_active_key);
+      assert.equal(result.erl_quota_key, params.elevated_limits.erl_quota_key);
     });
   });
 });


### PR DESCRIPTION
### Description

This PR changes the way we track ERL quota to address an edge case where the ERL quota changes in the middle of the month (before quota reset at the beginning of the next month).

It also collects all ERL configuration in a single place, so that the bucket overrides functionality can also be applied to ERL configuration.

**Before**:
* The first time ERL was activated, it was setting in redis quotaKey = quotaGivenThroughParam . If quota=192, then quotaKey = 192 after that first activation.
* From that point on, every ERL activation it was basically decreasing the quota quotaKey = quotaKey-1
Until quotaKey=0 => then the tenant exhausted all the quota for the given month.
* With the current situation, if the quota configuration changes in the middle of the month, lets say from 192 to 384, that value will not be used anymore in the code until the quoteKey expires, which is at the end of month.

**After the changes in this PR:**
* The first time ERL is activated, it sets quotaKey = 1 .
* From that point on, every ERL activation it increases the quota: quotakey = quotaKey+1 until quotaKey=quotaGivenThroughParam. At that point the tenant exhausted the quota for the given month.
If the tenant gets its quota increased, then quotaGivenThroughParam will be higher, and then quotaKey=quotaGivenThroughParam  will be false, hence ERL will be activate.


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
