### PR TITLE
fix: return correct bucket size [PSERV-2452]

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -334,7 +334,7 @@ class LimitDBRedis extends EventEmitter {
             conformant,
             remaining,
             reset: Math.ceil(reset / 1000),
-            limit: bucketKeyConfig.size,
+            limit: erl_activated ? elevated_limits.size : bucketKeyConfig.size,
             delayed: false,
             elevated_limits : {
               triggered: erl_triggered,

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -177,14 +177,13 @@ describe('LimitDBRedis', () => {
     const testsParams = [
       {
         name: 'regular take',
-        init: () => {
-        },
+        init: () => db.configurateBuckets(buckets),
         take: (params, callback) => db.take(params, callback),
         params: {}
       },
       {
         name: 'elevated take with no elevated configuration',
-        init: () => {},
+        init: () => db.configurateBuckets(buckets),
         take: (params, callback) => db.takeElevated(params, callback),
         params: {
           elevated_limits: {


### PR DESCRIPTION
### Description

While executing the load tests, we realised that even when the ERL is being used, we’re displaying the normal bucket size in http headers. This is creating confusion as sometimes it causes the remaining to be higher than the limit.

This PR fixes this by making sure that if ERL was active on the request, the ERL bucket size is returned; and the normal bucket size otherwise.

### References

https://auth0.slack.com/archives/C06DWRK540Y/p1714747757336829?thread_ts=1713272242.147539&cid=C06DWRK540Y

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
