### PR TITLE
fix: quota usage

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -302,7 +302,7 @@ class LimitDBRedis extends EventEmitter {
         ms_per_interval: bucketKeyConfig.ms_per_interval,
         size: bucketKeyConfig.size,
         erl_activation_period_seconds: 900,
-        erl_quota_amount: 0,
+        erl_quota: 0,
         erl_quota_interval: 'quota_per_calendar_month',
         erl_configured_for_bucket: false,
         ...bucketKeyConfig.elevated_limits
@@ -318,7 +318,7 @@ class LimitDBRedis extends EventEmitter {
         elevated_limits.ms_per_interval,
         elevated_limits.size,
         elevated_limits.erl_activation_period_seconds,
-        elevated_limits.erl_quota_amount,
+        elevated_limits.erl_quota,
         erl_quota_expiration,
         elevated_limits.erl_configured_for_bucket ? 1 : 0,
         (err, results) => {
@@ -345,7 +345,7 @@ class LimitDBRedis extends EventEmitter {
               triggered: erl_triggered,
               activated: erl_activate_for_bucket,
               quota_remaining: erl_quota_count,
-              quota_allocated: elevated_limits.erl_quota_amount,
+              quota_allocated: elevated_limits.erl_quota,
               erl_activation_period_seconds: elevated_limits.erl_activation_period_seconds,
             },
           };

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -57,7 +57,7 @@ local function takeERLQuota(erl_quota_key, erl_quota, erl_quota_expiration_epoch
     if type(previously_used_quota) ~= 'string' then
         -- first activation. Set quota to 1 and return.
         redis.call('SET', erl_quota_key, 1, 'PXAT', string.format('%.0f', erl_quota_expiration_epoch))
-        return 1
+        return 0
     end
 
     previously_used_quota = tonumber(previously_used_quota)
@@ -66,15 +66,9 @@ local function takeERLQuota(erl_quota_key, erl_quota, erl_quota_expiration_epoch
         return previously_used_quota
     end
 
-    if is_erl_activated == 1 then
-        -- erl is already activated. No need to increase quota count. Return the current total used quota.
-        return previously_used_quota
-    end
-
     -- quota is not exceeded. Increment and return.
-    local new_total_used_quota = previously_used_quota + 1
-    redis.call('SET', erl_quota_key, new_total_used_quota, 'PXAT', string.format('%.0f', erl_quota_expiration_epoch))
-    return new_total_used_quota
+    redis.call('SET', erl_quota_key, previously_used_quota+1, 'PXAT', string.format('%.0f', erl_quota_expiration_epoch))
+    return previously_used_quota
 end
 
 -- Enable verbatim replication to ensure redis sends script's source code to all masters

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -66,9 +66,13 @@ local function takeERLQuota(erl_quota_key, erl_quota, erl_quota_expiration_epoch
         return previously_used_quota
     end
 
+    if is_erl_activated == 1 then
+        -- erl is already activated. No need to increase quota count. Return the current total used quota.
+        return previously_used_quota
+    end
+
     -- quota is not exceeded. Increment and return.
     local new_total_used_quota = previously_used_quota + 1
-
     redis.call('SET', erl_quota_key, new_total_used_quota, 'PXAT', string.format('%.0f', erl_quota_expiration_epoch))
     return new_total_used_quota
 end

--- a/lib/take_elevated.lua
+++ b/lib/take_elevated.lua
@@ -111,7 +111,7 @@ else
                 redis.call('EXPIRE', erlKey, erl_activation_period_seconds)
                 is_erl_activated = 1
                 erl_triggered = true
-                erl_quota_left = erl_quota - previously_used_quota
+                erl_quota_left = erl_quota - previously_used_quota - 1
             end
         end
     end

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,11 +64,11 @@ function normalizeElevatedTemporals(params) {
     if (!(intervalShortcut in params)) {
       return;
     }
-    type.erl_quota_amount = params[intervalShortcut];
+    type.erl_quota = params[intervalShortcut];
     type.erl_quota_interval = intervalShortcut;
   });
 
-  if (!type.erl_quota_interval || type.erl_quota_amount === undefined) {
+  if (!type.erl_quota_interval || type.erl_quota === undefined) {
     throw new LimitdRedisConfigurationError('a valid quota amount per interval is required for elevated limits', {code: 202});
   }
 

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -34,7 +34,7 @@ describe('utils', () => {
 
       expect(elevated_limits).excluding('drip_interval').to.deep.equal({
         size: 300,
-        erl_quota_amount: 192,
+        erl_quota: 192,
         erl_quota_interval: 'quota_per_calendar_month',
         interval: 1000,
         per_interval: 300,
@@ -101,7 +101,7 @@ describe('utils', () => {
       });
       expect(overrides['127.0.0.1'].elevated_limits).excluding('drip_interval').to.deep.equal({
         erl_activation_period_seconds: 900,
-        erl_quota_amount: 10,
+        erl_quota: 10,
         erl_quota_interval: "quota_per_calendar_month",
         size: 400,
         interval: 1000,


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

We realised that the `takeElevated.lua` script wasn't working as expected -- it wasn't allowing the user to consume the last erl quota they have. The reason was that we were returning  1 as the `previously used quota` at the first ERL activation.

This PR fixes this issue, and adjusts the rest of the code accordingly.


### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing (locally at least)
- [x] The correct base branch is being used, if not the default branch
