### PR TITLE
ci: add basic CI with github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
-
 name: Test
 
 on:
@@ -13,6 +12,9 @@ jobs:
   docker:
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
       - name: Checkout
@@ -24,7 +26,7 @@ jobs:
       - name: Install node
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Start containers
-        run: docker-compose -f "docker-compose.yml" up redis toxiproxy -d --build
+        run: docker-compose -f "docker-compose.yml" up -d --build
 
       - name: Install node
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  docker:
+  test:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+
+name: Test
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  docker:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Start containers
+        run: docker-compose -f "docker-compose.yml" up redis toxiproxy -d --build
+
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 16.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Stop containers
+        run: docker-compose -f "docker-compose.yml" down


### PR DESCRIPTION
### Description

Adds some basic CI using github actions to run our test suite.

![image](https://github.com/auth0/limitd-redis/assets/36539330/c0bd5625-a0ea-4ea7-bf65-0fd41acc7460)

### References

Adopt github actions for OSS tooling: https://oktawiki.atlassian.net/wiki/spaces/A0ENG/pages/2561368475/GitHub+Actions
