### PR TITLE
refactor: improve jsdoc types

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -196,7 +196,7 @@ class LimitDBRedis extends EventEmitter {
    * Take N elements from a bucket if available.
    *
    * @param {TakeParams} params - The params for take.
-   * @param {function(Error, TakeResult)} callback.
+   * @param {function(null, TakeResult) | function(Error)} callback
    * @param {function(key: string, bucketKeyConfig: NormalizedType, count: number)} takeFunc
    */
   _doTake(params, callback, takeFunc) {
@@ -257,8 +257,7 @@ class LimitDBRedis extends EventEmitter {
    * Take N elements from a bucket if available.
    *
    * @param {TakeParams} params
-   * @param {function(Error)} callback.
-   * @param {function(null, TakeResult)} callback.
+   * @param {function(null, TakeResult) | function(Error)} callback
    */
   take(params, callback) {
     this._doTake(params, callback, (key, bucketKeyConfig, count) => {
@@ -295,8 +294,7 @@ class LimitDBRedis extends EventEmitter {
    * Take N elements from a bucket if available, use elevated limits if configured.
    *
    * @param {TakeElevatedParams} params
-   * @param {function(null, TakeElevatedResult)} callback.
-   * @param {function(Error)} callback.
+   * @param {function(null, TakeElevatedResult) | function(Error)} callback
    */
   takeElevated(params, callback) {
     let erlParams;
@@ -365,7 +363,7 @@ class LimitDBRedis extends EventEmitter {
    * The callback is called when the number of request tokens is available.
    *
    * @param {WaitParams} params - The params for take.
-   * @param {function(Error, WaitResult)} callback.
+   * @param {function(null, WaitResult) | function(Error)} callback
    */
   wait(params, callback) {
     this.take(params, (err, result) => {
@@ -395,7 +393,7 @@ class LimitDBRedis extends EventEmitter {
    * Put N elements in the bucket.
    *
    * @param {PutParams} params - The params for take.
-   * @param {function(Error, PutResult)} [callback].
+   * @param {function(null, PutResult) | function(Error)} [callback]
    */
   put(params, callback) {
     callback = callback || _.noop;
@@ -448,7 +446,7 @@ class LimitDBRedis extends EventEmitter {
    * Get elements in the bucket.
    *
    * @param {GetParams} params - The params for take.
-   * @param {function(Error, GetResult)} [callback].
+   * @param {function(null, GetResult) | function(Error)} [callback]
    */
   get(params, callback) {
     callback = callback || _.noop;

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,3 +1,4 @@
+/// <reference path="types.js" />
 const ms = require('ms');
 const fs = require('fs');
 const _ = require('lodash');
@@ -37,7 +38,7 @@ class LimitDBRedis extends EventEmitter {
 
   /**
    * Creates an instance of LimitDB client for Redis.
-   * @param {params} params - The configuration for the database and client.
+   * @param {LimitDBParams} params - The configuration for the database and client.
    */
   constructor(config) {
     super();
@@ -149,9 +150,9 @@ class LimitDBRedis extends EventEmitter {
   }
 
   /**
-   * @param {string} type
-   * @param {object} params
-   * @returns
+   * @param {type & { overrides: Object?, overridesCache: Object?, overridesMatch: Object? }} type
+   * @param {GetParams | PutParams | TakeParams | TakeElevatedParams} params
+   * @returns {NormalizedType}
    */
   bucketKeyConfig(type, params) {
     if (typeof params.configOverride === 'object') {
@@ -194,9 +195,9 @@ class LimitDBRedis extends EventEmitter {
   /**
    * Take N elements from a bucket if available.
    *
-   * @param {takeParams} params - The params for take.
-   * @param {function(Error, takeResult)} callback.
-   * @param {function(key, bucketKeyConfig, count)} takeFunc
+   * @param {TakeParams} params - The params for take.
+   * @param {function(Error, TakeResult)} callback.
+   * @param {function(key: string, bucketKeyConfig: NormalizedType, count: number)} takeFunc
    */
   _doTake(params, callback, takeFunc) {
     const valError = validateParams(params, this.buckets);
@@ -255,8 +256,9 @@ class LimitDBRedis extends EventEmitter {
   /**
    * Take N elements from a bucket if available.
    *
-   * @param {takeParams} params - The params for take.
-   * @param {function(Error, takeResult)} callback.
+   * @param {TakeParams} params
+   * @param {function(Error)} callback.
+   * @param {function(null, TakeResult)} callback.
    */
   take(params, callback) {
     this._doTake(params, callback, (key, bucketKeyConfig, count) => {
@@ -289,6 +291,13 @@ class LimitDBRedis extends EventEmitter {
     })
   }
 
+  /**
+   * Take N elements from a bucket if available, use elevated limits if configured.
+   *
+   * @param {TakeElevatedParams} params
+   * @param {function(null, TakeElevatedResult)} callback.
+   * @param {function(Error)} callback.
+   */
   takeElevated(params, callback) {
     let erlParams;
 
@@ -355,8 +364,8 @@ class LimitDBRedis extends EventEmitter {
    * Take N elements from a bucket if available otherwise wait for them.
    * The callback is called when the number of request tokens is available.
    *
-   * @param {waitParams} params - The params for take.
-   * @param {function(Error, waitResult)} callback.
+   * @param {WaitParams} params - The params for take.
+   * @param {function(Error, WaitResult)} callback.
    */
   wait(params, callback) {
     this.take(params, (err, result) => {
@@ -385,8 +394,8 @@ class LimitDBRedis extends EventEmitter {
   /**
    * Put N elements in the bucket.
    *
-   * @param {putParams} params - The params for take.
-   * @param {function(Error, putResult)} [callback].
+   * @param {PutParams} params - The params for take.
+   * @param {function(Error, PutResult)} [callback].
    */
   put(params, callback) {
     callback = callback || _.noop;
@@ -438,8 +447,8 @@ class LimitDBRedis extends EventEmitter {
   /**
    * Get elements in the bucket.
    *
-   * @param {getParams} params - The params for take.
-   * @param {function(Error, getResult)} [callback].
+   * @param {GetParams} params - The params for take.
+   * @param {function(Error, GetResult)} [callback].
    */
   get(params, callback) {
     callback = callback || _.noop;
@@ -509,68 +518,3 @@ class LimitDBRedis extends EventEmitter {
 
 
 module.exports = LimitDBRedis;
-
-/**
- * And now some typedefs for you:
- *
- * @typedef {Object} type
- * @property {integer} [per_interval] The number of tokens to add per interval.
- * @property {integer} [interval] The length of the interval in milliseconds.
- * @property {integer} [size] The maximum number of tokens in the bucket.
- * @property {integer} [per_second] The number of tokens to add per second. Equivalent to "interval: 1000, per_interval: x".
- * @property {integer} [per_minute] The number of tokens to add per minute. Equivalent to "interval: 60000, per_interval: x".
- * @property {integer} [per_hour] The number of tokens to add per hour. Equivalent to "interval: 3600000, per_interval: x".
- * @property {integer} [per_day] The number of tokens to add per day. Equivalent to "interval: 86400000, per_interval: x".
- *
- * @typedef {Object} params
- * uri nodes buckets prefix
- * @property {string} [params.uri] Address of Redis.
- * @property {Object.<string, object>} [params.nodes] Redis Cluster Configuration https://github.com/luin/ioredis#cluster".
- * @property {Object.<string, type>} [params.types] The buckets configuration.
- * @property {string} [params.prefix] Prefix keys in Redis.
- * @property {type} [params.configOverride] Bucket configuration override
- *
- * @typedef takeParams
- * @property {string} type The name of the bucket type.
- * @property {string} key The key of the bucket instance.
- * @property {integer} [count=1] The number of tokens to take from the bucket.
- * @property {type} configOverride Externally provided bucket configruation
- *
- * @typedef takeResult
- * @property {boolean} conformant Returns true if there is enough capacity in the bucket and the tokens has been removed.
- * @property {integer} remaining The number of tokens remaining in the bucket.
- * @property {integer} reset A unix timestamp indicating when the bucket is going to be full.
- * @property {integer} limit The size of the bucket.
- *
- * @typedef waitParams
- * @property {string} type The name of the bucket type.
- * @property {string} key The key of the bucket instance.
- * @property {integer} [count=1] The number of tokens to wait for.
- * @property {type} configOverride Externally provided bucket configruation
- *
- * @typedef waitResult
- * @property {integer} remaining The number of tokens remaining in the bucket.
- * @property {integer} reset A unix timestamp indicating when the bucket is going to be full.
- * @property {integer} limit The size of the bucket.
- *
- * @typedef putParams
- * @property {string} type The name of the bucket type.
- * @property {string} key The key of the bucket instance.
- * @property {integer} [count=SIZE] The number of tokens to put in the bucket. Defaults to the size of the bucket.
- * @property {type} configOverride Externally provided bucket configruation
- *
- * @typedef putResult
- * @property {integer} remaining The number of tokens remaining in the bucket.
- * @property {integer} reset A unix timestamp indicating when the bucket is going to be full.
- * @property {integer} limit The size of the bucket.
- *
- * @typedef getParams
- * @property {string} type The name of the bucket type.
- * @property {string} key The key of the bucket instance.
- * @property {type} configOverride Externally provided bucket configruation
- *
- * @typedef getResult
- * @property {integer} remaining The number of tokens remaining in the bucket.
- * @property {integer} reset A unix timestamp indicating when the bucket is going to be full.
- * @property {integer} limit The size of the bucket.
-*/

--- a/lib/db.js
+++ b/lib/db.js
@@ -150,7 +150,7 @@ class LimitDBRedis extends EventEmitter {
   }
 
   /**
-   * @param {type & { overrides: Object?, overridesCache: Object?, overridesMatch: Object? }} type
+   * @param {Bucket & { overrides: Object?, overridesCache: Object?, overridesMatch: Object? }} type
    * @param {GetParams | PutParams | TakeParams | TakeElevatedParams} params
    * @returns {NormalizedType}
    */

--- a/lib/types.js
+++ b/lib/types.js
@@ -5,13 +5,13 @@
  * uri nodes buckets prefix
  * @property {string} [params.uri] Address of Redis.
  * @property {Object.<string, object>} [params.nodes] Redis Cluster Configuration https://github.com/luin/ioredis#cluster".
- * @property {Object.<string, type>} [params.types] The buckets configuration.
+ * @property {Object.<string, Bucket>} [params.types] The buckets configuration.
  * @property {string} [params.prefix] Prefix keys in Redis.
- * @property {type} [params.configOverride] Bucket configuration override
+ * @property {Bucket} [params.configOverride] Bucket configuration override
  */
 
 /**
-* @typedef {Object} type
+* @typedef {Object} Bucket
 * @property {number} [per_interval] The number of tokens to add per interval.
 * @property {number} [interval] The length of the interval in milliseconds.
 * @property {number} [size] The maximum number of tokens in the bucket.
@@ -29,7 +29,7 @@
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
  * @property {number} [count=1] The number of tokens to take from the bucket.
- * @property {type} configOverride Externally provided bucket configuration
+ * @property {Bucket} configOverride Externally provided bucket configuration
 */
 
 /**
@@ -45,7 +45,7 @@
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
  * @property {number} [count=1] The number of tokens to wait for.
- * @property {type} configOverride Externally provided bucket configruation
+ * @property {Bucket} configOverride Externally provided bucket configuration
  */
 
 /**
@@ -60,7 +60,7 @@
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
  * @property {number} [count=SIZE] The number of tokens to put in the bucket. Defaults to the size of the bucket.
- * @property {type} configOverride Externally provided bucket configruation
+ * @property {Bucket} configOverride Externally provided bucket configruation
  */
  
 /**
@@ -74,7 +74,7 @@
  * @typedef GetParams
  * @property {string} type The name of the bucket type.
  * @property {string} key The key of the bucket instance.
- * @property {type} configOverride Externally provided bucket configuration
+ * @property {Bucket} configOverride Externally provided bucket configuration
  */
 
 /**
@@ -90,7 +90,7 @@
  * @property {string} key - The key of the bucket instance.
  * @property {number} [count=1] - The number of tokens to take from the bucket.
  * @property {ElevatedLimitParams} [elevated_limits] - (Optional) The elevated limit configuration.
- * @property {type} configOverride Externally provided bucket configuration
+ * @property {Bucket} configOverride Externally provided bucket configuration
  */
 
 /**

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,0 +1,155 @@
+// --- Public Types ---
+
+/**
+ * @typedef {Object} LimitDBParams
+ * uri nodes buckets prefix
+ * @property {string} [params.uri] Address of Redis.
+ * @property {Object.<string, object>} [params.nodes] Redis Cluster Configuration https://github.com/luin/ioredis#cluster".
+ * @property {Object.<string, type>} [params.types] The buckets configuration.
+ * @property {string} [params.prefix] Prefix keys in Redis.
+ * @property {type} [params.configOverride] Bucket configuration override
+ */
+
+/**
+* @typedef {Object} type
+* @property {number} [per_interval] The number of tokens to add per interval.
+* @property {number} [interval] The length of the interval in milliseconds.
+* @property {number} [size] The maximum number of tokens in the bucket.
+* @property {number} [per_second] The number of tokens to add per second. Equivalent to "interval: 1000, per_interval: x".
+* @property {number} [per_minute] The number of tokens to add per minute. Equivalent to "interval: 60000, per_interval: x".
+* @property {number} [per_hour] The number of tokens to add per hour. Equivalent to "interval: 3600000, per_interval: x".
+* @property {number} [per_day] The number of tokens to add per day. Equivalent to "interval: 86400000, per_interval: x".
+* @property {number} [unlimited] the maximum number of tokens in the bucket. equivalent to "size: x".
+* @property {number} [skip_n_calls] the number of calls to skip. equivalent to "size: x".
+* @property {ElevatedLimitParams} [elevated_limits] The elevated limit configuration.
+*/
+
+/**
+ * @typedef TakeParams
+ * @property {string} type The name of the bucket type.
+ * @property {string} key The key of the bucket instance.
+ * @property {number} [count=1] The number of tokens to take from the bucket.
+ * @property {type} configOverride Externally provided bucket configuration
+*/
+
+/**
+ * @typedef TakeResult
+ * @property {boolean} conformant Returns true if there is enough capacity in the bucket and the tokens has been removed.
+ * @property {number} remaining The number of tokens remaining in the bucket.
+ * @property {number} reset A unix timestamp indicating when the bucket is going to be full.
+ * @property {number} limit The size of the bucket.
+ */
+/**
+
+ * @typedef WaitParams
+ * @property {string} type The name of the bucket type.
+ * @property {string} key The key of the bucket instance.
+ * @property {number} [count=1] The number of tokens to wait for.
+ * @property {type} configOverride Externally provided bucket configruation
+ */
+
+/**
+ * @typedef WaitResult
+ * @property {number} remaining The number of tokens remaining in the bucket.
+ * @property {number} reset A unix timestamp indicating when the bucket is going to be full.
+ * @property {number} limit The size of the bucket.
+ */
+
+/**
+ * @typedef PutParams
+ * @property {string} type The name of the bucket type.
+ * @property {string} key The key of the bucket instance.
+ * @property {number} [count=SIZE] The number of tokens to put in the bucket. Defaults to the size of the bucket.
+ * @property {type} configOverride Externally provided bucket configruation
+ */
+ 
+/**
+ * @typedef PutResult
+ * @property {number} remaining The number of tokens remaining in the bucket.
+ * @property {number} reset A unix timestamp indicating when the bucket is going to be full.
+ * @property {number} limit The size of the bucket.
+ */
+
+/**
+ * @typedef GetParams
+ * @property {string} type The name of the bucket type.
+ * @property {string} key The key of the bucket instance.
+ * @property {type} configOverride Externally provided bucket configuration
+ */
+
+/**
+ * @typedef GetResult
+ * @property {number} remaining The number of tokens remaining in the bucket.
+ * @property {number} reset A unix timestamp indicating when the bucket is going to be full.
+ * @property {number} limit The size of the bucket.
+ */
+
+/**
+ * @typedef {Object} TakeElevatedParams
+ * @property {string} type - The name of the bucket type.
+ * @property {string} key - The key of the bucket instance.
+ * @property {number} [count=1] - The number of tokens to take from the bucket.
+ * @property {ElevatedLimitParams} [elevated_limits] - (Optional) The elevated limit configuration.
+ * @property {type} configOverride Externally provided bucket configuration
+ */
+
+/**
+ * @typedef {Object} ElevatedLimitParams
+ * @property {string} erl_is_active_key - The key to check if the elevated limits are active.
+ * @property {string} erl_quota_key - The key to store the quota for the elevated limits.
+ * @property {number} erl_activation_period_seconds - The activation period for the elevated limits in seconds.
+ * // temporal options
+ * @property {number} [per_interval] The number of tokens to add per interval.
+ * @property {number} [interval] The length of the interval in milliseconds.
+ * @property {number} [size] The maximum number of tokens in the bucket.
+ * @property {number} [per_second] The number of tokens to add per second. Equivalent to "interval: 1000, per_interval: x".
+ * @property {number} [per_minute] The number of tokens to add per minute. Equivalent to "interval: 60000, per_interval: x".
+ * @property {number} [per_hour] The number of tokens to add per hour. Equivalent to "interval: 3600000, per_interval: x".
+ * @property {number} [per_day] The number of tokens to add per day. Equivalent to "interval: 86400000, per_interval: x".
+ * @property {number} [unlimited] The maximum number of tokens in the bucket. Equivalent to "size: x".
+ */
+
+/**
+ * @typedef {Object} TakeElevatedResult
+ * @property {boolean} conformant - Returns true if there is enough capacity in the bucket and the tokens has been removed.
+ * @property {number} remaining - The number of tokens remaining in the bucket.
+ * @property {number} reset - A unix timestamp indicating when the bucket is going to be full.
+ * @property {number} limit - The size of the bucket.
+ * @property {boolean} delayed - Indicates if the operation was delayed.
+ * @property {Elevated_result} elevated_limits - The elevated limit result
+ */
+
+/**
+ * @typedef {Object} Elevated_result
+ * @property {boolean} erl_configured_for_bucket - Indicates if the bucket is configured for elevated limits.
+ * @property {boolean} triggered - Indicates if the elevated limits were triggered.
+ * @property {boolean} activated - Indicates if the elevated limits were activated.
+ * @property {number} quota_remaining - The remaining quota for elevated limits.
+ * @property {number} quota_allocated - The allocated quota for elevated limits.
+ * @property {number} erl_activation_period_seconds - The activation period for elevated limits in seconds.
+ */
+
+// --- Internal Types ---
+
+/**
+ * @typedef {Object} NormalizedType -- the internal representation of a bucket
+ * @property {number} [per_interval] The number of tokens to add per interval.
+ * @property {number} [interval] The length of the interval in milliseconds.
+ * @property {number} [size] The maximum number of tokens in the bucket.
+ * @property {number} [ttl] The time to live for the bucket in seconds.
+ * @property {number} [ms_per_interval] The number of milliseconds per interval.
+ * @property {number} [drip_interval] The interval for the drip in milliseconds.
+ * @property {number} [unlimited] the maximum number of tokens in the bucket. equivalent to "size: x".
+ * @property {number} [skip_n_calls] the number of calls to skip. equivalent to "size: x".
+ * @property {NormalizedType} [elevated_limits] The elevated limit configuration.
+ * @property {boolean} [erl_configured_for_bucket] Indicates if the bucket is configured for elevated limits.
+ */
+
+/**
+ * @typedef {Object} ElevatedLimitConfiguration
+ * @property {string} erl_is_active_key - The key to check if the elevated limits are active.
+ * @property {string} erl_quota_key - The key to store the quota for the elevated limits.
+ * @property {number} erl_activation_period_seconds - The activation period for the elevated limits in seconds.
+ * @property {number} erl_quota - The quota for the elevated limits.
+ * @property {string} erl_quota_interval - The interval for the quota.
+ */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,3 +1,4 @@
+/// <reference path="types.js" />
 const ms = require('ms');
 const _ = require('lodash');
 const LRU = require('lru-cache');
@@ -142,6 +143,12 @@ function randomBetween(min, max) {
   return Math.random() * (max - min) + min;
 }
 
+/**
+ * Extracts ERL configuration from the ERL parameters
+ *
+ * @param {ElevatedLimitParams} params The object to extract the ERL parameters from.
+ * @returns {ElevatedLimitConfiguration} The extracted ERL parameters.
+ */
 function getERLParams(params) {
   const type = _.pick(params, [
     'erl_is_active_key',
@@ -169,6 +176,13 @@ function endOfMonthTimestamp() {
   return Date.UTC(curDate.getUTCFullYear(), curDate.getUTCMonth() + 1, 1, 0, 0, 0, 0);
 }
 
+/**
+ * Resolves the elevated parameters by providing default values for elevated_limits unless they are defined in the bucketKeyConfig.
+ *
+ * @param {ElevatedLimitParams} erlParams - The ERL parameters to resolve.
+ * @param {NormalizedType} bucketKeyConfig - The configuration of the bucket key.
+ * @returns {NormalizedType & ElevatedLimitConfiguration} The resolved ERL parameters.
+ */
 function resolveElevatedParams(erlParams, bucketKeyConfig) {
   // provide default values for elevated_limits unless the bucketKeyConfig has them
   return {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,7 +17,12 @@ const ERL_QUOTA_INTERVALS = {
 };
 const ERL_QUOTA_INTERVALS_SHORTCUTS = Object.keys(ERL_QUOTA_INTERVALS);
 
-function normalizeTemporals(params) {
+/**
+ *
+ * @param {type} params
+ * @returns {NormalizedType}
+ */
+function parseIntervals(params) {
   const type = _.pick(params, [
     'per_interval',
     'interval',
@@ -43,19 +48,24 @@ function normalizeTemporals(params) {
     type.ms_per_interval = type.per_interval / type.interval;
     type.drip_interval = type.interval / type.per_interval;
   }
-
-  if (params.elevated_limits) {
-    type.elevated_limits = normalizeElevatedTemporals(params.elevated_limits);
-  }
-
-  return type;
+  return type
 }
 
-function normalizeElevatedTemporals(params) {
-  let type = normalizeTemporals(params);
+/**
+ *
+ * @param {type} params
+ * @returns {NormalizedType}
+ */
+function normalizeTemporals(params) {
+  const type = parseIntervals(params);
 
-  if (typeof type.size !== 'undefined' && typeof type.per_interval !== 'undefined') {
-    type.erl_configured_for_bucket = true;
+  if (params.elevated_limits) {
+    const elevatedLimits = parseIntervals(params.elevated_limits);
+    const isErlDefined = !_.isUndefined(elevatedLimits.size) && !_.isUndefined(elevatedLimits.per_interval);
+    type.elevated_limits = {
+      ...elevatedLimits,
+      erl_configured_for_bucket: isErlDefined,
+    };
   }
 
   return type;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,7 +20,7 @@ const ERL_QUOTA_INTERVALS_SHORTCUTS = Object.keys(ERL_QUOTA_INTERVALS);
 
 /**
  *
- * @param {type} params
+ * @param {Bucket} params
  * @returns {NormalizedType}
  */
 function parseIntervals(params) {
@@ -54,7 +54,7 @@ function parseIntervals(params) {
 
 /**
  *
- * @param {type} params
+ * @param {Bucket} params
  * @returns {NormalizedType}
  */
 function normalizeTemporals(params) {
@@ -114,7 +114,7 @@ function normalizeType(params) {
 /**
  * Load the buckets configuration.
  *
- * @param {Object.<string, type>} bucketsConfig The buckets configuration.
+ * @param {Object.<string, Bucket>} bucketsConfig The buckets configuration.
  * @memberof LimitDB
  */
 function buildBuckets(bucketsConfig) {

--- a/lib/validation.js
+++ b/lib/validation.js
@@ -58,6 +58,12 @@ function validateOverride(configOverride) {
   }
 }
 
+/**
+ * Validates the elevated limits parameters.
+ *
+ * @param {ElevatedLimitConfiguration} params The parameters to validate.
+ * @returns {LimitdRedisValidationError | void} The error, if any.
+ */
 function validateERLParams(params) {
   if (!params) {
     return new LimitdRedisValidationError('elevated_limits object is required for elevated limits', { code: 107 });


### PR DESCRIPTION
### Description

This PR:
- adds missing jsdoc types to public function arguments and return values.
- adds some jsdoc types for internal functions.
- centralizes jsdoc types for use across the project.

The end result is a better user experience (intellisense and documentation for the public interface) and a better developer experience for contributors (type hints for internal functions).

![image](https://github.com/auth0/limitd-redis/assets/36539330/9a8a402b-603c-4027-a587-5df9a683a624)

![image](https://github.com/auth0/limitd-redis/assets/36539330/a1c83059-dada-4fe1-88c4-e082dfbff9f1)


### References

N/A

### Testing

N/A

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
