### PR TITLE
Overrides when using hashtag

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,8 @@ Examples:
 | Curly brace within hashtag | `limitd.takeElevated('bucketName', '{{some-key}')`            | `{some-key`               | `bucketName:{{some-key}`            | `ERLActiveKey:{{some-key}`               | `ERLQuotaKey:{{some-key}`               |
 | Empty hashtag              | `limitd.takeElevated('bucketName', '{}{some-key}')`           | `bucketName:{}{some-key}` | `bucketName:{}{some-key}`           | `ERLActiveKey:{bucketName:{}{some-key}}` | `ERLQuotaKey:{bucketName:{}{some-key}}` |
 
+To address the issue where overrides typically target keys without the hashtag, we sanitize the received key by removing the hashtag before looking for overrides. 
+If any overrides are found, they will be applied accordingly.
 
 ## Breaking changes from `Limitdb`
 

--- a/lib/db.js
+++ b/lib/db.js
@@ -7,7 +7,7 @@ const utils = require('./utils');
 const Redis = require('ioredis');
 const { validateParams, validateERLParams } = require('./validation');
 const DBPing = require("./db_ping");
-const { calculateQuotaExpiration, resolveElevatedParams, isFixedWindowEnabled } = require('./utils');
+const { calculateQuotaExpiration, resolveElevatedParams, isFixedWindowEnabled, removeHashtag } = require('./utils');
 const EventEmitter = require('events').EventEmitter;
 
 const TAKE_LUA = fs.readFileSync(`${__dirname}/take.lua`, "utf8");
@@ -161,21 +161,23 @@ class LimitDBRedis extends EventEmitter {
       return utils.normalizeTemporals(params.configOverride);
     }
 
-    const fromOverride = type.overrides[params.key];
+    const key = removeHashtag(params.key);
+
+    const fromOverride = type.overrides[key];
     if (fromOverride) {
       return fromOverride;
     }
 
-    const fromCache = type.overridesCache && type.overridesCache.get(params.key);
+    const fromCache = type.overridesCache && type.overridesCache.get(key);
     if (fromCache) {
       return fromCache;
     }
 
     const fromMatch = _.find(type.overridesMatch, (o) => {
-      return o.match.exec(params.key);
+      return o.match.exec(key);
     });
     if (fromMatch) {
-      type.overridesCache.set(params.key, fromMatch);
+      type.overridesCache.set(key, fromMatch);
       return fromMatch;
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -220,6 +220,13 @@ function replicateHashtag(baseKey, prefix, key) {
   }
 }
 
+function removeHashtag(key) {
+  if (key.startsWith('{') && key.endsWith('}')) {
+    return key.slice(1, -1);
+  }
+  return key;
+}
+
 /** isFixedWindowEnabled
  * | fixed_window bucket config | fixed_window param | Fixed Window Enabled |
  * |----------------------------|--------------------|----------------------|
@@ -252,4 +259,5 @@ module.exports = {
   resolveElevatedParams,
   replicateHashtag,
   isFixedWindowEnabled,
+  removeHashtag,
 };

--- a/test/db.tests.js
+++ b/test/db.tests.js
@@ -2149,6 +2149,45 @@ module.exports.tests = (clientCreator) => {
           });
         });
       });
+
+      describe('when using overrides', () => {
+        const testBuckets = {
+          ip: {
+            size: 10,
+            per_second: 5,
+            overrides: {
+              '127.0.0.1': {
+                per_second: 100
+              }
+            },
+          }
+        }
+
+        const testCases = [
+          { description: 'when the key contains curly braces', key: '{127.0.0.1}', expectedLimit: 100 },
+          { description: 'when the key does not contain curly braces', key: '127.0.0.1', expectedLimit: 100 },
+        ];
+        testCases.forEach(({ description, key, expectedLimit }) => {
+          describe(description, () => {
+            it('should apply the override', (done) => {
+              const takeParams = { type: 'ip', key };
+
+              db.configurateBuckets(testBuckets);
+
+              db.take(takeParams, (err, result) => {
+                if (err) {
+                  return done(err);
+                }
+
+                assert.ok(result.conformant);
+                assert.equal(result.remaining, expectedLimit - 1);
+                assert.equal(result.limit, expectedLimit);
+                done();
+              });
+            });
+          });
+        });
+      });
     });
 
     describe('PUT', () => {

--- a/test/utils.tests.js
+++ b/test/utils.tests.js
@@ -5,7 +5,9 @@ const chaiExclude = require('chai-exclude');
 chai.use(chaiExclude);
 const assert = chai.assert;
 
-const { getERLParams, calculateQuotaExpiration, normalizeType, resolveElevatedParams, replicateHashtag, isFixedWindowEnabled } = require('../lib/utils');
+const { getERLParams, calculateQuotaExpiration, normalizeType, resolveElevatedParams, replicateHashtag, isFixedWindowEnabled,
+  removeHashtag
+} = require('../lib/utils');
 const { set, reset } = require('mockdate');
 const { expect } = require('chai');
 
@@ -429,6 +431,38 @@ describe('utils', () => {
     it('should return false when fixed_window bucket config is not present and fixed_window param is true', () => {
       const result = isFixedWindowEnabled(undefined, true);
       assert.isFalse(result);
+    });
+  });
+
+  describe('removeHashtag', () => {
+    it('should remove curly braces from a key with both curly braces', () => {
+      const key = '{127.0.0.1}';
+      const result = removeHashtag(key);
+      expect(result).to.equal('127.0.0.1');
+    });
+
+    it('should return the key unchanged if it does not have curly braces', () => {
+      const key = '127.0.0.1';
+      const result = removeHashtag(key);
+      expect(result).to.equal(key);
+    });
+
+    it('should return the key unchanged if it only has the left curly brace', () => {
+      const key = '{127.0.0.1';
+      const result = removeHashtag(key);
+      expect(result).to.equal(key);
+    });
+
+    it('should return the key unchanged if it only has the right curly brace', () => {
+      const key = '127.0.0.1}';
+      const result = removeHashtag(key);
+      expect(result).to.equal(key);
+    });
+
+    it('should remove the outermost curly braces if the key has nested curly braces', () => {
+      const key = '{{127.0.0.1}}';
+      const result = removeHashtag(key);
+      expect(result).to.equal('{127.0.0.1}');
     });
   });
 });


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

When we introduced elevated rate limits, we also implemented the use of [Redis Hashtags](https://redis.io/docs/latest/operate/oss_and_stack/reference/cluster-spec/#hash-tags) to ensure that all keys involved in the elevated rate limits operation are allocated in the same Redis hash slot. This hashtagging process involves adding curly braces around the key.  

However, this introduced an issue: overrides typically target keys without the hashtag. As a result, if we use a key with hashtags, the overrides will not be applied.

This PR addresses the issue by sanitizing the received key by removing the hashtag before looking for overrides. If any overrides are found, they will be applied accordingly.

Example:

Given the following configuration
```
buckets: {
  ip: {
    size: 10,
    per_second: 5,
    overrides: {
      '127.0.0.1': {
        per_second: 100
      }
    },
  }
}
```

It will apply the overrides for: 
- `take('ip', '127.0.0.1')`
- `take('ip', '{127.0.0.1}')`

It will not apply the overrides for any other combination. 

### Testing

> Describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.
>
> Please include any manual steps for testing end-to-end or functionality not covered by unit/integration tests.
>
> Also include details of the environment this PR was developed in (language/platform/browser version).

- [ ] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not the default branch
