### PR TITLE
feat: add ability to delete redis keys on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,10 @@ and it returns the number of keys deleted.
 `limitd.del` takes the following as an argument:
 -  `keys` (string | string[]): redis key(s) to delete. It can be a string or an array of strings.
 
+⚠️ In clustered redis environment, if you want to delete multiple keys, you must run the
+command for each individual key separately. There is no guarantee all keys will be in the same
+cluster, and a single DEL can only delete multiple keys if they are the same cluster.
+
 It returns:
 - `result` (int): the number of keys deleted. (If 0, key didn't exist)
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ limitd.del('my-key', (err, result) => {
 ```
 
 `limitd.del` takes the following as an argument:
--  `keys` (string | string[]): redis key(s) to delete. It can be a string or an array of strings.
+-  `key` (string): redis key to delete.
 
 It returns:
 - `result` (int): the number of keys deleted. (If 0, key didn't exist)

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ The following table describes how the fixed window bucket configuration and the 
 
 ## PUT
 
-You can manually reset a fill a bucket using PUT:
+You can manually reset or fill a bucket using PUT:
 
 ```js
 limitd.put(type, key, [count], (err, result) => {
@@ -352,6 +352,29 @@ limitd.put(type, key, [count], (err, result) => {
 -  `key`: the identifier of the bucket.
 -  `count`: the amount of tokens you want to put in the bucket. This is optional and the default is the size of the bucket.
 -  `configOverride`: caller-provided bucket configuration for this operation
+
+## DEL
+
+You can delete a specific key (or a list of keys) using DEL:
+
+```js
+limitd.del('single-key', (err, result) => {
+  console.log(result);
+});
+
+limitd.del(['key1', 'key2'], (err, result) => {
+  console.log(result);
+});
+```
+It works similarly to the `DEL` command in Redis; it accepts a single key or an array of keys to delete, 
+and it returns the number of keys deleted.
+
+`limitd.del` takes the following as an argument:
+-  `keys` (string | string[]): redis key(s) to delete. It can be a string or an array of strings.
+
+It returns:
+- `result` (int): the number of keys deleted. (If 0, key didn't exist)
+
 
 ## Overriding Configuration at Runtime
 Since the method of storing overrides for buckets in memory does not scale to a large number, limitd-redis provides a way for callers to pass in configuration from an external data store.  The shape of this `configOverride` parameter (available on `take`, `put`, `get`, and `wait`) is exactly the same as `Buckets` above ^.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It's a fork from [LimitDB](https://github.com/limitd/limitdb).
 - [TAKEELEVATED](#takeelevated)
   - [Use of fixed window on Take and TakeElevated](#use-of-fixed-window-on-take-and-takeelevated)
 - [PUT](#put)
+- [DEL](#del)
 - [Overriding Configuration at Runtime](#overriding-configuration-at-runtime)
    - [Overriding Configuration at Runtime with ERL](#overriding-configuration-at-runtime-with-erl)
 - [Testing](#testing)
@@ -355,26 +356,17 @@ limitd.put(type, key, [count], (err, result) => {
 
 ## DEL
 
-You can delete a specific key (or a list of keys) using DEL:
+You can delete a specific Redis key using DEL:
 
 ```js
-limitd.del('single-key', (err, result) => {
+limitd.del('my-key', (err, result) => {
   console.log(result);
 });
 
-limitd.del(['key1', 'key2'], (err, result) => {
-  console.log(result);
-});
 ```
-It works similarly to the `DEL` command in Redis; it accepts a single key or an array of keys to delete, 
-and it returns the number of keys deleted.
 
 `limitd.del` takes the following as an argument:
 -  `keys` (string | string[]): redis key(s) to delete. It can be a string or an array of strings.
-
-⚠️ In clustered redis environment, if you want to delete multiple keys, you must run the
-command for each individual key separately. There is no guarantee all keys will be in the same
-cluster, and a single DEL can only delete multiple keys if they are the same cluster.
 
 It returns:
 - `result` (int): the number of keys deleted. (If 0, key didn't exist)

--- a/lib/client.js
+++ b/lib/client.js
@@ -123,6 +123,10 @@ class LimitdRedis extends EventEmitter {
     this.handler('put', type, key, opts, cb);
   }
 
+  del(type, keys, opts, cb) {
+    this.handler('del', type, keys, opts, cb);
+  }
+
   reset(type, key, opts, cb) {
     this.put(type, key, opts, cb);
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -123,8 +123,8 @@ class LimitdRedis extends EventEmitter {
     this.handler('put', type, key, opts, cb);
   }
 
-  del(type, keys, opts, cb) {
-    this.handler('del', type, keys, opts, cb);
+  del(key, opts, cb) {
+    this.handler('del', null, key, opts, cb);
   }
 
   reset(type, key, opts, cb) {

--- a/lib/db.js
+++ b/lib/db.js
@@ -504,6 +504,25 @@ class LimitDBRedis extends EventEmitter {
   }
 
   /**
+   * Delete one or more keys from Redis.
+   *
+   * @param {string|string[]} keys - The key or list of keys to delete.
+   * @param {function(Error, delResult)} [callback] - The callback.
+   */
+  del(keys, callback) {
+    callback = callback || _.noop;
+
+    keys = Array.isArray(keys) ? keys : [keys];
+
+    this.redis.del(keys, (err, result) => {
+      if (err) {
+        return callback(new Error(`Failed deleting key(s) ${keys}: ${err.message}`));
+      }
+      callback(null, result);
+    });
+  }
+
+  /**
    * Resets/re-fills all keys in all buckets.
    * @param {function(Error)} [callback].
    */
@@ -599,4 +618,6 @@ module.exports = LimitDBRedis;
  * @property {integer} remaining The number of tokens remaining in the bucket.
  * @property {integer} reset A unix timestamp indicating when the bucket is going to be full.
  * @property {integer} limit The size of the bucket.
+ *
+ * @typedef delResult The number of keys deleted. If 0, key doesn't exist.
 */

--- a/lib/db.js
+++ b/lib/db.js
@@ -506,25 +506,14 @@ class LimitDBRedis extends EventEmitter {
   /**
    * Delete one or more keys from Redis.
    *
-   * @param {string|string[]} keys - The key or list of keys to delete.
+   * @param {delParams} params - The params for del.
    * @param {function(Error, delResult)} [callback] - The callback.
    */
-  del(keys, callback) {
+  del(params, callback) {
     callback = callback || _.noop;
-
-    keys = Array.isArray(keys) ? keys : [keys];
-
-    this.redis.del(keys, (err, result) => {
+    this.redis.del(params.key, (err, result) => {
       if (err) {
-        let delErr = new Error(`Failed deleting key(s) ${keys}: ${err.message}`);
-        if (err.message.includes('CROSSSLOT') && this.redis.isCluster) {
-          delErr.name = 'CrossSlotError';
-          delErr.message = delErr.message + '\nYou are likely receiving this error because you ' +
-              'are in a in clustered redis environment. The keys you listed might be living in ' +
-              'different clusters, which a single DEL command cannot handle. Please try again ' +
-              'by running the command separately for each key instead.';
-        }
-        return callback(delErr);
+        return callback(err);
       }
       callback(null, result);
     });
@@ -627,5 +616,7 @@ module.exports = LimitDBRedis;
  * @property {integer} reset A unix timestamp indicating when the bucket is going to be full.
  * @property {integer} limit The size of the bucket.
  *
- * @typedef delResult The number of keys deleted. If 0, key doesn't exist.
+ * @typedef delParams
+ * @property {string} key The key to delete
+ * @typedef {integer} delResult The number of keys deleted. If 1, passed key  was deleted. If 0, key doesn't exist.
 */

--- a/lib/db.js
+++ b/lib/db.js
@@ -516,7 +516,15 @@ class LimitDBRedis extends EventEmitter {
 
     this.redis.del(keys, (err, result) => {
       if (err) {
-        return callback(new Error(`Failed deleting key(s) ${keys}: ${err.message}`));
+        let delErr = new Error(`Failed deleting key(s) ${keys}: ${err.message}`);
+        if (err.message.includes('CROSSSLOT') && this.redis.isCluster) {
+          delErr.name = 'CrossSlotError';
+          delErr.message = delErr.message + '\nYou are likely receiving this error because you ' +
+              'are in a in clustered redis environment. The keys you listed might be living in ' +
+              'different clusters, which a single DEL command cannot handle. Please try again ' +
+              'by running the command separately for each key instead.';
+        }
+        return callback(delErr);
       }
       callback(null, result);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd-redis",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "description": "A database client for limits on top of redis",
   "main": "index.js",
   "repository": {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -187,6 +187,17 @@ module.exports = (clientCreator) => {
       });
     });
 
+    describe('#del', () => {
+      it('should call #handle with del as the method', (done) => {
+        client.handler = (method, type, keys, cb) => {
+          assert.equal(method, 'del');
+          assert.equal(keys, ['testkey']);
+          cb();
+        };
+        client.del('test', 'testkey', done);
+      });
+    });
+
     describe('#reset', () => {
       it('should call #put', (done) => {
         client.put = (type, key, count, cb) => {

--- a/test/client.tests.js
+++ b/test/client.tests.js
@@ -189,12 +189,12 @@ module.exports = (clientCreator) => {
 
     describe('#del', () => {
       it('should call #handle with del as the method', (done) => {
-        client.handler = (method, type, keys, cb) => {
+        client.handler = (method, type, key, cb) => {
           assert.equal(method, 'del');
-          assert.equal(keys, ['testkey']);
+          assert.equal(key, 'testkey');
           cb();
         };
-        client.del('test', 'testkey', done);
+        client.del('testkey', done);
       });
     });
 

--- a/test/db.clustermode.tests.js
+++ b/test/db.clustermode.tests.js
@@ -13,7 +13,7 @@ describe('when using LimitDB', () => {
       return new LimitDB({ nodes: clusterNodes, buckets: {}, prefix: 'tests:', ..._.omit(params, ['uri']) });
     };
 
-    dbTests(clientCreator);
+    dbTests(clientCreator, true);
 
     describe('when using the clustered #constructor', () => {
       it('should allow setting username and password', (done) => {

--- a/test/db.clustermode.tests.js
+++ b/test/db.clustermode.tests.js
@@ -13,7 +13,7 @@ describe('when using LimitDB', () => {
       return new LimitDB({ nodes: clusterNodes, buckets: {}, prefix: 'tests:', ..._.omit(params, ['uri']) });
     };
 
-    dbTests(clientCreator, true);
+    dbTests(clientCreator);
 
     describe('when using the clustered #constructor', () => {
       it('should allow setting username and password', (done) => {

--- a/test/db.standalonemode.tests.js
+++ b/test/db.standalonemode.tests.js
@@ -14,7 +14,7 @@ describe('when using LimitDB', () => {
       return new LimitDB({ uri: 'localhost:6379', buckets: {}, prefix: 'tests:', ..._.omit(params, ['nodes']) });
     };
 
-    dbTests(clientCreator, false);
+    dbTests(clientCreator);
 
     describe('when using the standalone #constructor', () => {
       it('should emit error on failure to connect to redis', (done) => {

--- a/test/db.standalonemode.tests.js
+++ b/test/db.standalonemode.tests.js
@@ -14,7 +14,7 @@ describe('when using LimitDB', () => {
       return new LimitDB({ uri: 'localhost:6379', buckets: {}, prefix: 'tests:', ..._.omit(params, ['nodes']) });
     };
 
-    dbTests(clientCreator);
+    dbTests(clientCreator, false);
 
     describe('when using the standalone #constructor', () => {
       it('should emit error on failure to connect to redis', (done) => {

--- a/test/db.standalonemode.tests.js
+++ b/test/db.standalonemode.tests.js
@@ -2,10 +2,6 @@
 const LimitDB = require('../lib/db');
 const _ = require('lodash');
 const { tests: dbTests, buckets} = require('./db.tests');
-const { assert } = require('chai');
-const { Toxiproxy, Toxic } = require('toxiproxy-node-client');
-const crypto = require('crypto');
-
 
 
 describe('when using LimitDB', () => {


### PR DESCRIPTION
_By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo._

### Description

We are faced with a usecase that requires us to delete specific redis key(s) on demand to manipulate the rate limiting behaviour.

This PR adds `del` function to `limitd` client interface.
Upon agreement, for now, the function will only support a single key deletion at a time.
https://redis.io/docs/latest/commands/del/

### Testing

- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [x] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
