### PR TITLE
fix: carry over fixed_window attribute to overrides

### DIFF
--- a/.github/workflows/redis-tests.yml
+++ b/.github/workflows/redis-tests.yml
@@ -31,13 +31,13 @@ jobs:
         run: npm install
 
       - name: Setup Standalone Tests
-        run: make test-standalone-redis-setup
+        run: make integration-standalone-redis-setup
 
       - name: Run Standalone tests
-        run: make test-standalone-run
+        run: make integration-standalone-run
 
       - name: Teardown Standalone Tests
-        run: make test-standalone-redis-teardown
+        run: make integration-standalone-redis-teardown
 
   redis-cluster:
     env:
@@ -64,13 +64,13 @@ jobs:
         run: npm install
 
       - name: Setup Clustered Tests
-        run: make test-cluster-redis-setup
+        run: make integration-cluster-redis-setup
 
       - name: Check Redis Cluster
         run: timeout 60 bash <<< "until redis-cli -c -p 16371 cluster info | grep 'cluster_state:ok'; do sleep 1; done"
 
       - name: Run Clustered tests
-        run: make test-cluster-run
+        run: make integration-cluster-run
 
       - name: Teardown Clustered Tests
-        run: make test-cluster-redis-teardown
+        run: make integration-cluster-redis-teardown

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,34 @@
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  unit-tests:
+    env:
+      CI: true
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Test
+        run: make test

--- a/.github/workflows/valkey-tests.yml
+++ b/.github/workflows/valkey-tests.yml
@@ -31,13 +31,13 @@ jobs:
         run: npm install
 
       - name: Setup Standalone Tests
-        run: make test-standalone-valkey-setup
+        run: make integration-standalone-valkey-setup
 
       - name: Run Standalone tests
-        run: make test-standalone-run
+        run: make integration-standalone-run
 
       - name: Teardown Standalone Tests
-        run: make test-standalone-valkey-teardown
+        run: make integration-standalone-valkey-teardown
 
   valkey-cluster:
     env:
@@ -64,13 +64,13 @@ jobs:
         run: npm install
 
       - name: Setup Clustered Tests
-        run: make test-cluster-valkey-setup
+        run: make integration-cluster-valkey-setup
 
       - name: Check valkey Cluster
         run: timeout 60 bash <<< "until redis-cli -c -p 16371 cluster info | grep 'cluster_state:ok'; do sleep 1; done"
 
       - name: Run Clustered tests
-        run: make test-cluster-run
+        run: make integration-cluster-run
 
       - name: Teardown Clustered Tests
-        run: make test-cluster-valkey-teardown
+        run: make integration-cluster-valkey-teardown

--- a/Makefile
+++ b/Makefile
@@ -3,49 +3,50 @@ export CLUSTER_NO_TLS_VALIDATION=true
 
 VALKEY_DOCKER_IMAGE=bitnami/valkey:8.0.2-debian-12-r5
 REDIS_DOCKER_IMAGE=redis:6
+.PHONY: test integration integration-% integration-setup-% integration-teardown-% integration-standalone-redis-setup integration-standalone-valkey-setup integration-standalone-redis-teardown integration-standalone-valkey-teardown integration-cluster-redis-setup integration-cluster-valkey-setup integration-cluster-redis-teardown integration-cluster-valkey-teardown integration-cluster-run integration-standalone-run integration-teardown-all
 
-test: test-redis test-valkey
+test:
+	npm run test
+integration: integration-redis integration-valkey
 	@echo "All tests executed"
 
-test-%: test-setup-% test-standalone-run test-cluster-run test-teardown-%
+integration-%: integration-setup-% integration-standalone-run integration-cluster-run integration-teardown-%
 	@echo "Test executed"
 
-test-setup-%: test-standalone-%-setup test-cluster-%-setup
+integration-setup-%: integration-standalone-%-setup integration-cluster-%-setup
 	@echo "Test setup executed"
 
-test-teardown-%: test-standalone-%-teardown test-cluster-%-teardown
+integration-teardown-%: integration-standalone-%-teardown integration-cluster-%-teardown
 	@echo "Test teardown executed"
 
-test-standalone-redis-setup:
+integration-standalone-redis-setup:
 	REDIS_IMAGE=${REDIS_DOCKER_IMAGE} docker compose up -d
 
-test-standalone-valkey-setup:
+integration-standalone-valkey-setup:
 	REDIS_IMAGE=${VALKEY_DOCKER_IMAGE} docker compose up -d
 
-test-standalone-redis-teardown:
+integration-standalone-redis-teardown:
 	REDIS_IMAGE=${REDIS_DOCKER_IMAGE} docker compose down
 
-test-standalone-valkey-teardown:
+integration-standalone-valkey-teardown:
 	REDIS_IMAGE=${VALKEY_DOCKER_IMAGE} docker compose down
 
-test-cluster-redis-setup:
+integration-cluster-redis-setup:
 	REDIS_IMAGE=${REDIS_DOCKER_IMAGE} docker compose -f docker-compose-cluster.yml up -d
 
-test-cluster-valkey-setup:
+integration-cluster-valkey-setup:
 	REDIS_IMAGE=${VALKEY_DOCKER_IMAGE} docker compose -f docker-compose-cluster.yml up -d
 
-test-cluster-redis-teardown:
+integration-cluster-redis-teardown:
 	REDIS_IMAGE=${REDIS_DOCKER_IMAGE} docker compose -f docker-compose-cluster.yml down
 
-test-cluster-valkey-teardown:
+integration-cluster-valkey-teardown:
 	REDIS_IMAGE=${VALKEY_DOCKER_IMAGE} docker compose -f docker-compose-cluster.yml down
 
-test-cluster-run:
-	npm run test-cluster
+integration-cluster-run:
+	npm run test-integration-cluster
 
-test-standalone-run:
-	npm run test-standalone
+integration-standalone-run:
+	npm run test-integration-standalone
 
-test-teardown-all: test-standalone-redis-teardown test-cluster-redis-teardown test-standalone-valkey-teardown test-cluster-valkey-teardown
-
-
+integration-teardown-all: integration-standalone-redis-teardown integration-cluster-redis-teardown integration-standalone-valkey-teardown integration-cluster-valkey-teardown

--- a/lib/db.js
+++ b/lib/db.js
@@ -66,7 +66,10 @@ class LimitDBRedis extends EventEmitter {
     };
 
     this.redis = null;
-    if (config.nodes) {
+
+    if (config.mocks?.redis) {
+      this.redis = config.mocks.redis;
+    } else if (config.nodes) {
       if (config.username) {
         clusterOptions.redisOptions.username = config.username;
       }

--- a/lib/db.js
+++ b/lib/db.js
@@ -133,18 +133,31 @@ class LimitDBRedis extends EventEmitter {
    */
   bucketKeyConfig(type, params) {
     if (typeof params.configOverride === 'object') {
-      return utils.normalizeTemporals(params.configOverride);
+      // Merge fixed_window from base type if not specified in override
+      const config = {
+        fixed_window: type.fixed_window,
+        ...params.configOverride,
+      };
+      return utils.normalizeTemporals(config);
     }
 
     const key = removeHashtag(params.key);
 
     const fromOverride = type.overrides[key];
     if (fromOverride) {
+      // Merge fixed_window from base type if not specified in override
+      if (typeof fromOverride.fixed_window === 'undefined') {
+        fromOverride.fixed_window = type.fixed_window;
+      }
       return fromOverride;
     }
 
     const fromCache = type.overridesCache && type.overridesCache.get(key);
     if (fromCache) {
+      // Merge fixed_window from base type if not in cached value
+      if (typeof fromCache.fixed_window === 'undefined') {
+        fromCache.fixed_window = type.fixed_window;
+      }
       return fromCache;
     }
 
@@ -152,6 +165,10 @@ class LimitDBRedis extends EventEmitter {
       return o.match.exec(key);
     });
     if (fromMatch) {
+      // Merge fixed_window from base type if not specified in match override
+      if (typeof fromMatch.fixed_window === 'undefined') {
+        fromMatch.fixed_window = type.fixed_window;
+      }
       type.overridesCache.set(key, fromMatch);
       return fromMatch;
     }

--- a/lib/db.js
+++ b/lib/db.js
@@ -67,8 +67,8 @@ class LimitDBRedis extends EventEmitter {
 
     this.redis = null;
 
-    if (config.mocks?.redis) {
-      this.redis = config.mocks.redis;
+    if (config.redis) {
+      this.redis = config.redis;
     } else if (config.nodes) {
       if (config.username) {
         clusterOptions.redisOptions.username = config.username;

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "url": "http://github.com/auth0/limitd-redis.git"
   },
   "scripts": {
-    "test-standalone": "NODE_ENV=test nyc mocha --exit --exclude '**/*clustermode*'",
-    "test-cluster": "NODE_ENV=test nyc mocha --exit  --exclude '**/*standalonemode*'"
+    "test-integration-standalone": "NODE_ENV=test nyc mocha --exit --exclude '**/*clustermode*'",
+    "test-integration-cluster": "NODE_ENV=test nyc mocha --exit  --exclude '**/*standalonemode*'",
+    "test": "NODE_ENV=test nyc mocha --exit test/unit"
   },
   "author": "Auth0",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "limitd-redis",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "description": "A database client for limits on top of redis",
   "main": "index.js",
   "repository": {

--- a/test/unit/cb.tests.js
+++ b/test/unit/cb.tests.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 var assert = require('assert'),
-  cb = require('../lib/cb');
+  cb = require('../../lib/cb');
 
 function invokeAsync(callback) {
   setTimeout(function() {

--- a/test/unit/db.tests.js
+++ b/test/unit/db.tests.js
@@ -1,0 +1,492 @@
+/* eslint-disable */
+const { assert } = require("chai");
+const sinon = require("sinon");
+const LimitDBRedis = require("../../lib/db");
+const Redis = require("ioredis");
+
+describe("LimitDBRedis", () => {
+  let db;
+  let redisMock;
+
+  beforeEach(() => {
+    // Mock Redis instance
+    redisMock = {
+      defineCommand: sinon.stub(),
+      on: sinon.stub(),
+      take: sinon.stub(),
+      takeElevated: sinon.stub(),
+      takeExponential: sinon.stub(),
+      put: sinon.stub(),
+      hmget: sinon.stub(),
+      del: sinon.stub(),
+      quit: sinon.stub(),
+      nodes: null,
+    };
+
+    // Create test instance
+    db = new LimitDBRedis({
+      uri: "redis://localhost:6379",
+      buckets: {
+        ip: {
+          size: 10,
+          per_second: 5,
+        },
+      },
+      mocks: {
+        redis: redisMock,
+      },
+    });
+
+    // Simulate ready event
+    redisMock.on
+      .getCalls()
+      .find((call) => call.args[0] === "ready")
+      ?.args[1]();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("#take", () => {
+    it("should call redis take with correct parameters", (done) => {
+      // Mock redis response
+      const now = Date.now();
+      redisMock.take.callsFake((key, ms, size, count, ttl, drip, fixed, cb) => {
+        cb(null, [5, 1, now, now + 1000]);
+      });
+
+      db.take(
+        {
+          type: "ip",
+          key: "1.2.3.4",
+          count: 1,
+        },
+        (err, result) => {
+          assert.isNull(err);
+          assert.isTrue(result.conformant);
+          assert.equal(result.remaining, 5);
+          assert.equal(result.limit, 10);
+          assert.isFalse(result.delayed);
+
+          sinon.assert.calledWith(
+            redisMock.take,
+            "ip:1.2.3.4",
+            0.005, // ms_per_interval (5/1000 tokens per ms)
+            10, // size
+            1, // count
+            sinon.match.number, // ttl
+            200, // drip_interval
+            0 // fixed window interval
+          );
+          done();
+        }
+      );
+    });
+
+    it("should handle redis errors", (done) => {
+      redisMock.take.callsFake((key, ms, size, count, ttl, drip, fixed, cb) => {
+        cb(new Error("Redis error"));
+      });
+
+      db.take(
+        {
+          type: "ip",
+          key: "1.2.3.4",
+        },
+        (err, result) => {
+          assert.isNotNull(err);
+          assert.equal(err.message, "Redis error");
+          assert.isUndefined(result);
+          done();
+        }
+      );
+    });
+
+    it("should validate params", (done) => {
+      db.take({}, (err) => {
+        assert.match(err.message, /type is required/);
+        done();
+      });
+    });
+
+    it("should handle unlimited buckets", (done) => {
+      db.configurateBucket("unlimited", {
+        size: 100,
+        unlimited: true,
+      });
+
+      db.take(
+        {
+          type: "unlimited",
+          key: "test",
+        },
+        (err, result) => {
+          assert.isNull(err);
+          assert.isTrue(result.conformant);
+          assert.equal(result.remaining, 100);
+          assert.equal(result.limit, 100);
+          assert.isFalse(result.delayed);
+          done();
+        }
+      );
+    });
+  });
+
+  describe("#wait", () => {
+    it("should retry when bucket is not conformant", (done) => {
+      const clock = sinon.useFakeTimers();
+      let calls = 0;
+
+      redisMock.take.callsFake((key, ms, size, count, ttl, drip, fixed, cb) => {
+        calls++;
+        if (calls === 1) {
+          cb(null, [0, 0, Date.now(), Date.now() + 1000]);
+        } else {
+          cb(null, [5, 1, Date.now(), Date.now() + 1000]);
+        }
+      });
+
+      db.wait(
+        {
+          type: "ip",
+          key: "1.2.3.4",
+        },
+        (err, result) => {
+          assert.isNull(err);
+          assert.isTrue(result.conformant);
+          assert.isTrue(result.delayed);
+          assert.equal(calls, 2);
+          done();
+        }
+      );
+
+      clock.tick(200);
+      clock.restore();
+    });
+  });
+
+  describe("#put", () => {
+    it("should call redis put with correct parameters", (done) => {
+      const now = Date.now();
+      redisMock.put.callsFake((key, count, size, ttl, drip, cb) => {
+        cb(null, [10, now, now, now + 1000]);
+      });
+
+      db.put(
+        {
+          type: "ip",
+          key: "1.2.3.4",
+          count: 5,
+        },
+        (err, result) => {
+          assert.isNull(err);
+          assert.equal(result.remaining, 10);
+          assert.equal(result.limit, 10);
+
+          sinon.assert.calledWith(
+            redisMock.put,
+            "ip:1.2.3.4",
+            5, // count
+            10, // size
+            sinon.match.number, // ttl
+            200 // drip interval
+          );
+          done();
+        }
+      );
+    });
+  });
+
+  describe("#del", () => {
+    it("should call redis del with correct key", (done) => {
+      redisMock.del.callsFake((key, cb) => cb(null, 1));
+
+      db.del(
+        {
+          key: "test:key",
+        },
+        (err, result) => {
+          assert.isNull(err);
+          assert.equal(result, 1);
+          sinon.assert.calledWith(redisMock.del, "test:key");
+          done();
+        }
+      );
+    });
+  });
+
+  describe("#get", () => {
+    it("should return bucket info", (done) => {
+      redisMock.hmget.callsFake((key, r, d, cb) => {
+        cb(null, [5, Date.now()]);
+      });
+
+      db.get(
+        {
+          type: "ip",
+          key: "1.2.3.4",
+        },
+        (err, result) => {
+          assert.isNull(err);
+          assert.equal(result.remaining, 5);
+          assert.equal(result.limit, 10);
+          assert.isNumber(result.reset);
+          done();
+        }
+      );
+    });
+  });
+
+  describe("#configurateBuckets", () => {
+    it("should update buckets configuration", () => {
+      db.configurateBuckets({
+        test: { size: 5, per_second: 1 },
+      });
+      assert.equal(db.buckets.test.size, 5);
+      assert.equal(db.buckets.test.per_interval, 1);
+      assert.equal(db.buckets.test.interval, 1000);
+    });
+  });
+
+  describe("#configurateBucket", () => {
+    it("should add new bucket configuration", () => {
+      db.configurateBucket("test", { size: 5, per_second: 1 });
+      assert.equal(db.buckets.test.size, 5);
+      assert.equal(db.buckets.test.per_interval, 1);
+      assert.equal(db.buckets.test.interval, 1000);
+    });
+  });
+
+  describe("#bucketKeyConfig", () => {
+    beforeEach(() => {
+      db.configurateBucket("test", {
+        size: 10,
+        per_second: 5, // Will be normalized to per_interval: 5, interval: 1000
+        overrides: {
+          "exact-match": {
+            size: 20,
+            per_second: 10,
+          },
+          "override-with-erl": {
+            elevated_limits: {
+              size: 100,
+              per_second: 50,
+            },
+          },
+          "pattern-match": {
+            match: "^pattern-.*",
+            size: 30,
+          },
+          "local-ips": {
+            match: "^192\\.168\\.",
+            size: 40,
+          },
+          expired: {
+            size: 50,
+            until: new Date(Date.now() - 1000), // Past date
+          },
+          future: {
+            size: 60,
+            until: new Date(Date.now() + 1000 * 60 * 60), // 1 hour in future
+          },
+        },
+      });
+    });
+
+    it("should return config override when provided", () => {
+      const config = db.bucketKeyConfig(db.buckets.test, {
+        key: "any-key",
+        configOverride: { size: 15, per_second: 7 },
+      });
+      assert.equal(config.size, 15);
+      assert.equal(config.per_interval, 7);
+      assert.equal(config.interval, 1000); // 1 second in ms
+    });
+
+    it("should return exact match from overrides", () => {
+      const config = db.bucketKeyConfig(db.buckets.test, {
+        key: "exact-match",
+      });
+      assert.equal(config.size, 20);
+      assert.equal(config.per_interval, 10);
+      assert.equal(config.interval, 1000);
+    });
+
+    it("should handle override with only elevated limits", () => {
+      const config = db.bucketKeyConfig(db.buckets.test, {
+        key: "override-with-erl",
+      });
+      assert.equal(config.size, 10); // Base config
+      assert.equal(config.per_interval, 5); // Base config
+      assert.equal(config.interval, 1000);
+      // Assert only the properties we care about in elevated_limits
+      assert.equal(config.elevated_limits.size, 100);
+      assert.equal(config.elevated_limits.per_interval, 50);
+      assert.equal(config.elevated_limits.interval, 1000);
+    });
+
+    it("should return regex match from overrides", () => {
+      const config = db.bucketKeyConfig(db.buckets.test, {
+        key: "pattern-123",
+      });
+      assert.equal(config.size, 30);
+    });
+
+    it("should return IP pattern match from overrides", () => {
+      const config = db.bucketKeyConfig(db.buckets.test, {
+        key: "192.168.1.1",
+      });
+      assert.equal(config.size, 40);
+    });
+
+    it("should ignore expired overrides", () => {
+      const config = db.bucketKeyConfig(db.buckets.test, {
+        key: "expired",
+      });
+      assert.equal(config.size, 10); // Default size
+    });
+
+    it("should use future overrides", () => {
+      const config = db.bucketKeyConfig(db.buckets.test, {
+        key: "future",
+      });
+      assert.equal(config.size, 60);
+    });
+
+    it("should return cached match for repeated regex lookups", () => {
+      const key = "pattern-123";
+      // First call should cache
+      const config1 = db.bucketKeyConfig(db.buckets.test, { key });
+      assert.equal(config1.size, 30);
+
+      // Modify cache to verify next call uses cached value
+      db.buckets.test.overridesCache.set(key, { size: 999 });
+
+      const config2 = db.bucketKeyConfig(db.buckets.test, { key });
+      assert.equal(config2.size, 999);
+    });
+
+    it("should handle keys with hashtags", () => {
+      const config = db.bucketKeyConfig(db.buckets.test, {
+        key: "{exact-match}",
+      });
+      assert.equal(config.size, 20);
+    });
+
+    it("should return base config when no matches found", () => {
+      const config = db.bucketKeyConfig(db.buckets.test, {
+        key: "no-match",
+      });
+      assert.equal(config.size, 10);
+      assert.equal(config.per_interval, 5);
+      assert.equal(config.interval, 1000);
+    });
+
+    it("should normalize temporal values in returned config", () => {
+      const config = db.bucketKeyConfig(db.buckets.test, {
+        key: "exact-match",
+      });
+      assert.exists(config.per_interval);
+      assert.exists(config.interval);
+      assert.exists(config.ms_per_interval);
+    });
+  });
+
+  describe("#takeExponential", () => {
+    it("should call redis takeExponential with correct parameters", (done) => {
+      const now = Date.now();
+      redisMock.takeExponential.callsFake(
+        (key, ms, size, count, ttl, drip, factor, unit, fixed, cb) => {
+          cb(null, [5, 1, now, now + 1000, 2, 1000, now + 2000]);
+        }
+      );
+
+      db.takeExponential(
+        {
+          type: "ip",
+          key: "1.2.3.4",
+        },
+        (err, result) => {
+          assert.isNull(err);
+          assert.isTrue(result.conformant);
+          assert.equal(result.remaining, 5);
+          assert.equal(result.backoff_factor, 2);
+          assert.equal(result.backoff_time, 1000);
+          done();
+        }
+      );
+    });
+  });
+
+  describe("#takeElevated", () => {
+    it("should call redis takeElevated with correct parameters", (done) => {
+      const now = Date.now();
+      redisMock.takeElevated.callsFake(
+        (
+          key,
+          active,
+          quota,
+          ms,
+          size,
+          count,
+          ttl,
+          drip,
+          fixed,
+          erlMs,
+          erlSize,
+          period,
+          quota_max,
+          exp,
+          config,
+          cb
+        ) => {
+          cb(null, [5, 1, now, now + 1000, 1, 1, 10]);
+        }
+      );
+
+      db.configurateBucket("elevated", {
+        size: 10,
+        per_second: 5,
+        elevated_limits: {
+          size: 20,
+          per_second: 10,
+        },
+      });
+
+      db.takeElevated(
+        {
+          type: "elevated",
+          key: "test",
+          elevated_limits: {
+            erl_is_active_key: "active",
+            erl_quota_key: "quota",
+            erl_activation_period_seconds: 900,
+            quota_per_calendar_month: 100,
+          },
+        },
+        (err, result) => {
+          assert.isNull(err);
+          assert.isTrue(result.conformant);
+          assert.equal(result.remaining, 5);
+          assert.isTrue(result.elevated_limits.triggered);
+          assert.isTrue(result.elevated_limits.activated);
+          done();
+        }
+      );
+    });
+  });
+
+  describe("#resetAll", () => {
+    it("should call flushdb on all master nodes", (done) => {
+      redisMock.nodes = () => [redisMock];
+      redisMock.flushdb = sinon.stub().callsFake((cb) => cb());
+
+      db.resetAll((err) => {
+        assert.isNull(err);
+        assert.isTrue(redisMock.flushdb.called);
+        done();
+      });
+    });
+  });
+});

--- a/test/unit/db.tests.js
+++ b/test/unit/db.tests.js
@@ -32,9 +32,7 @@ describe("LimitDBRedis", () => {
           per_second: 5,
         },
       },
-      mocks: {
-        redis: redisMock,
-      },
+      redis: redisMock,
     });
 
     // Simulate ready event
@@ -112,7 +110,6 @@ describe("LimitDBRedis", () => {
 
     it("should handle unlimited buckets", (done) => {
       db.configurateBucket("unlimited", {
-        size: 100,
         unlimited: true,
       });
 
@@ -124,8 +121,6 @@ describe("LimitDBRedis", () => {
         (err, result) => {
           assert.isNull(err);
           assert.isTrue(result.conformant);
-          assert.equal(result.remaining, 100);
-          assert.equal(result.limit, 100);
           assert.isFalse(result.delayed);
           done();
         }
@@ -240,12 +235,16 @@ describe("LimitDBRedis", () => {
 
   describe("#configurateBuckets", () => {
     it("should update buckets configuration", () => {
+      assert.equal(db.buckets.ip.size, 10);
+      assert.equal(db.buckets.ip.per_interval, 5);
+      assert.equal(db.buckets.ip.interval, 1000);
+
       db.configurateBuckets({
-        test: { size: 5, per_second: 1 },
+        ip: { size: 5, per_second: 1 },
       });
-      assert.equal(db.buckets.test.size, 5);
-      assert.equal(db.buckets.test.per_interval, 1);
-      assert.equal(db.buckets.test.interval, 1000);
+      assert.equal(db.buckets.ip.size, 5);
+      assert.equal(db.buckets.ip.per_interval, 1);
+      assert.equal(db.buckets.ip.interval, 1000);
     });
   });
 

--- a/test/unit/utils.tests.js
+++ b/test/unit/utils.tests.js
@@ -8,7 +8,7 @@ const assert = chai.assert;
 
 const { getERLParams, calculateQuotaExpiration, normalizeType, resolveElevatedParams, replicateHashtag, isFixedWindowEnabled,
   removeHashtag
-} = require('../lib/utils');
+} = require('../../lib/utils');
 const { set, reset } = require('mockdate');
 const { expect } = require('chai');
 

--- a/test/unit/validation.tests.js
+++ b/test/unit/validation.tests.js
@@ -2,7 +2,7 @@
 /* eslint-env node, mocha */
 const assert = require('chai').assert;
 
-const { validateParams, validateERLParams } = require('../lib/validation');
+const { validateParams, validateERLParams } = require('../../lib/validation');
 const _ = require('lodash');
 
 describe('validation', () => {


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description

We realised that overriding limits seemed to bring back the sliding window behaviour if the limit was set to fixed_window:
During testing we created an override setting the limit to 100 RPS. The moment the override hit the configuration, the behavior changed, we saw the sliding window behavior back in place.

After removing the override we were back to the fixed_window behavior.

### References

> Include any links supporting this change such as a:
>
> - GitHub Issue/PR number addressed or fixed
> - Auth0 Community post
> - StackOverflow post
> - Support forum thread
> - Related pull requests/issues from other repos
>
> If there are no references, simply delete this section.

### Testing

Tested live after applying an override:

![image](https://github.com/user-attachments/assets/8b165b5f-768e-4957-9a48-40876285a355)


- [x] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not the default branch
